### PR TITLE
feat: add deploy-ready Next.js analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+.env*
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,42 +1,101 @@
-# Tumor Diagnosis: Exploratory Data Analysis
+# Insights Studio Dashboard
 
-[**Kaggle Notebook**](https://www.kaggle.com/code/rasikasrimal/tumor-diagnosis)
+A deploy-ready Next.js analytics workspace that ingests CSV/JSON datasets and executed Jupyter notebooks, processes them on the server, and exposes interactive dashboards with charts, explorers, and notebook rendering. The project is optimised for deployment on Vercel and follows the UI conventions defined in `instructions.md`.
 
-![Dataset Cover](https://storage.googleapis.com/kaggle-datasets-images/180/384/3da2510581f9d3b902307ff8d06fe327/dataset-cover.jpg)
+## Features
 
-## About the Dataset
+- **Dataset ingestion pipeline** – Upload CSV or JSON files; parsing and data cleaning happen in an API route before storing in an in-memory registry.
+- **Notebook ingestion** – Upload `.ipynb` files, convert Markdown/code cells to HTML, and display outputs (including rich HTML and images) directly in the browser.
+- **Responsive dashboard pages** – Overview KPIs, chart gallery (line, bar, scatter, heatmap, map), data explorer table, and notebook viewer.
+- **Reusable hooks & utilities** – Shared hooks for fetching datasets/notebooks, data-cleaning utilities, and chart transformation helpers.
+- **UI enhancements** – Tailwind CSS styling with light/dark themes, upload forms, empty states, skeleton loaders, and authentication placeholders ready for integration.
+- **Server-side validation** – Robust error handling for uploads with helpful client feedback.
 
-The **Breast Cancer Diagnostic data** is sourced from the [UCI Machine Learning Repository](https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+%28Diagnostic%29). It is also accessible through the [UW CS FTP server](http://ftp.cs.wisc.edu/math-prog/cpo-dataset/machine-learn/cancer/WDBC/).
+## Project structure
 
-This dataset comprises features computed from digitized images of fine needle aspirates (FNA) of breast masses. These features describe the characteristics of cell nuclei present in the images. The dataset is discussed in the paper: [K. P. Bennett and O. L. Mangasarian: "Robust Linear Programming Discrimination of Two Linearly Inseparable Sets", Optimization Methods and Software 1, 1992, 23-34](https://doi.org/10.1080/10509589208826835).
+```
+src/
+  app/
+    api/              # File upload & data retrieval routes
+    (pages)/          # App Router pages (overview, charts, explorer, notebooks)
+  components/        # UI components, charts, upload forms, notebooks renderer
+  hooks/             # SWR-powered data fetching hooks
+  lib/               # CSV/JSON parsing, KPI calculations, chart helpers
+  stores/            # In-memory dataset/notebook registry
+  types/             # Shared TypeScript models
+```
 
-### Attribute Information
+## Getting started locally
 
-- **ID number**: Unique identifier for each instance.
-- **Diagnosis**: Class label (M = malignant, B = benign).
-- **Features**: Derived from the cell nuclei in the images, including:
-  1. Radius (mean of distances from center to points on the perimeter)
-  2. Texture (standard deviation of gray-scale values)
-  3. Perimeter
-  4. Area
-  5. Smoothness (local variation in radius lengths)
-  6. Compactness (perimeter^2 / area - 1.0)
-  7. Concavity (severity of concave portions of the contour)
-  8. Concave Points (number of concave portions of the contour)
-  9. Symmetry
-  10. Fractal Dimension ("coastline approximation" - 1)
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   > Uses Next.js `15.5.2`, React `18.3.1`, Tailwind CSS `4.1.13`, and supporting libraries listed in `package.json`.
 
-The dataset includes 30 features in total, with each feature having mean, standard error, and "worst" values.
+2. **Configure environment variables**
 
-- **Data Quality**: No missing values.
-- **Class Distribution**: 357 benign cases, 212 malignant cases.
+   Create a `.env.local` file (ignored by Git) and add any variables you need. Suggested placeholders:
+   ```bash
+   AUTH_SECRET=replace-with-your-auth-secret
+   NEXT_PUBLIC_MAP_TOKEN=optional-map-provider-token
+   ```
+   These variables are not yet consumed directly but give you a scaffold when wiring authentication or external map tiles.
 
-## Installation
+3. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:3000` to open the dashboard. Upload datasets/notebooks using the forms on the Overview and Notebooks pages.
 
-To run the notebook, you need the following dependencies:
+4. **Linting & type checks** (optional but recommended)
+   ```bash
+   npm run lint
+   npx tsc --noEmit
+   ```
 
-- Python 3.x
-- Jupyter Notebook
-- pandas
-- seaborn
-- matplotlib
+## Upload workflow
+
+- CSV files are parsed with `csv-parse/sync`. Headers are normalised (lowercase, snake_case) and rows with only empty values are dropped.
+- JSON files must contain an array of records. Values are coerced to numbers when possible.
+- Notebook files are parsed using `marked` for Markdown and custom output rendering to keep code cells, stdout, and rich outputs.
+- Uploaded assets are stored in-memory via `src/stores/data-store.ts`. Replace this with a database or blob store for production use.
+
+## Adding new datasets programmatically
+
+1. Extend `saveDataset` in `src/stores/data-store.ts` to persist data in your database.
+2. Update `src/lib/chart-data.ts` if you need bespoke aggregations or want to surface additional chart types.
+3. Adjust the frontend selectors (`ChartsClient`, `ExplorerClient`) to expose new metrics or dataset metadata fields.
+4. Wire authentication in `AuthStatus` (e.g., NextAuth) to restrict uploads.
+
+## Rendering additional notebook formats
+
+- Enhance `parseNotebookFile` in `src/lib/notebook.ts` to support alternative mimetypes (e.g., `image/jpeg`, `application/vnd.plotly.v1+json`).
+- Customise the `NotebookViewer` component to support cell collapsing, code execution metadata, or diffing between runs.
+
+## Deployment (Vercel)
+
+1. Push this repository to GitHub or GitLab.
+2. Create a new Vercel project and import the repo.
+3. Set environment variables under **Settings → Environment Variables** (mirror `.env.local`).
+4. Vercel automatically runs `npm install` and `npm run build`. The build output uses the Next.js App Router.
+5. After deployment, uploads remain in-memory per serverless function instance. For persistence, connect to external storage (e.g., Supabase, PlanetScale, Blob storage) and swap the store implementation.
+
+## Authentication placeholders
+
+`src/components/navigation/auth-status.tsx` mimics a logged-in user after a short delay. Replace its logic with your provider of choice. Keep the theme-toggle and upload components accessible by wrapping authenticated pages in your own guard.
+
+## Integrating new visualisations
+
+- The chart helpers (`src/lib/chart-data.ts`) generate data for the existing chart suite. Extend them to compute metrics for time-series decomposition, box plots, or custom ECharts configs.
+- When adding new charts, follow the `chart` components pattern: create a reusable card, ensure responsive containers, and avoid any shadow-based styling.
+
+## Troubleshooting
+
+- **Uploads fail with 413**: Increase `bodySizeLimit` in `next.config.mjs` or chunk uploads.
+- **Charts missing**: Confirm your dataset exposes the required columns (numeric for line/scatter, categorical for bar/heatmap, lat/lon for maps).
+- **Notebook rendering issues**: Ensure the `.ipynb` file includes executed cells; otherwise outputs will be empty.
+
+## License
+
+This project inherits the repository’s original license (if any). Update this section when publishing publicly.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/navigation-types/compat/navigation" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '8mb'
+    },
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "tumor-diagnosis-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "2.1.9",
+    "@heroicons/react": "2.1.5",
+    "@tanstack/react-table": "8.16.0",
+    "clsx": "2.1.0",
+    "csv-parse": "5.5.6",
+    "echarts": "5.5.0",
+    "echarts-for-react": "3.0.2",
+    "marked": "12.0.2",
+    "next": "15.5.2",
+    "next-themes": "0.3.0",
+    "prism-react-renderer": "2.3.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-simple-maps": "3.0.0",
+    "recharts": "2.12.7",
+    "swr": "2.2.4",
+    "tailwind-merge": "2.3.0",
+    "zustand": "5.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.5.4",
+    "@types/react": "18.3.5",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.20",
+    "postcss": "8.4.45",
+    "tailwindcss": "4.1.13",
+    "typescript": "5.6.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/(pages)/charts/page.tsx
+++ b/src/app/(pages)/charts/page.tsx
@@ -1,0 +1,15 @@
+import { ChartsClient } from '@/components/charts-client';
+
+export default function ChartsPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Charts</h1>
+        <p className="text-sm text-muted-foreground">
+          Visualise uploaded datasets with responsive charts. The server normalises and validates data before streaming to these components.
+        </p>
+      </header>
+      <ChartsClient />
+    </div>
+  );
+}

--- a/src/app/(pages)/explorer/page.tsx
+++ b/src/app/(pages)/explorer/page.tsx
@@ -1,0 +1,15 @@
+import { ExplorerClient } from '@/components/explorer-client';
+
+export default function ExplorerPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Explorer</h1>
+        <p className="text-sm text-muted-foreground">
+          Dive into row-level details with filtering and sorting tools. Datasets remain in-memory for rapid prototyping.
+        </p>
+      </header>
+      <ExplorerClient />
+    </div>
+  );
+}

--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { Sidebar } from '@/components/navigation/sidebar';
+import { MobileNav } from '@/components/navigation/mobile-nav';
+
+export default function PagesLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="lg:hidden">
+        <MobileNav />
+      </div>
+      <div className="mx-auto flex w-full max-w-7xl gap-6 px-4 py-6 lg:px-8">
+        <div className="hidden w-64 shrink-0 lg:block">
+          <Sidebar />
+        </div>
+        <main className="flex-1 space-y-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/notebooks/page.tsx
+++ b/src/app/(pages)/notebooks/page.tsx
@@ -1,0 +1,15 @@
+import { NotebooksClient } from '@/components/notebooks-client';
+
+export default function NotebooksPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Notebooks</h1>
+        <p className="text-sm text-muted-foreground">
+          Render executed Jupyter notebooks directly in the browser. Code cells, markdown, and outputs stay intact.
+        </p>
+      </header>
+      <NotebooksClient />
+    </div>
+  );
+}

--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -1,0 +1,15 @@
+import { OverviewClient } from '@/components/overview-client';
+
+export default function OverviewPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Overview</h1>
+        <p className="text-sm text-muted-foreground">
+          Upload datasets, monitor KPIs, and jump into deeper analysis. All uploads are processed on the server with type-safe utilities.
+        </p>
+      </header>
+      <OverviewClient />
+    </div>
+  );
+}

--- a/src/app/api/datasets/[id]/route.ts
+++ b/src/app/api/datasets/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getDataset } from '@/stores/data-store';
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const dataset = getDataset(params.id);
+  if (!dataset) {
+    return NextResponse.json({ error: 'Dataset not found.' }, { status: 404 });
+  }
+  return NextResponse.json(dataset);
+}

--- a/src/app/api/datasets/route.ts
+++ b/src/app/api/datasets/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { listDatasets } from '@/stores/data-store';
+
+export async function GET() {
+  const datasets = listDatasets();
+  return NextResponse.json(datasets);
+}

--- a/src/app/api/notebooks/[id]/route.ts
+++ b/src/app/api/notebooks/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getNotebook } from '@/stores/data-store';
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_request: NextRequest, { params }: Params) {
+  const notebook = getNotebook(params.id);
+  if (!notebook) {
+    return NextResponse.json({ error: 'Notebook not found.' }, { status: 404 });
+  }
+  return NextResponse.json(notebook);
+}

--- a/src/app/api/notebooks/route.ts
+++ b/src/app/api/notebooks/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import { listNotebooks } from '@/stores/data-store';
+
+export async function GET() {
+  return NextResponse.json(listNotebooks());
+}

--- a/src/app/api/upload/dataset/route.ts
+++ b/src/app/api/upload/dataset/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { parseCsv } from '@/lib/csv';
+import { cleanDataset, detectNumericFields } from '@/lib/data-cleaning';
+import { computeKpis } from '@/lib/kpis';
+import { extractGeoPoints } from '@/lib/chart-data';
+import { saveDataset } from '@/stores/data-store';
+import type { DatasetRecord, DatasetRow } from '@/types/data';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'A dataset file is required.' }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const text = buffer.toString('utf-8');
+    const extension = (file.name.split('.').pop() ?? '').toLowerCase();
+
+    let rows: DatasetRow[];
+    if (extension === 'csv') {
+      rows = parseCsv(text);
+    } else if (extension === 'json') {
+      const parsed = JSON.parse(text);
+      if (!Array.isArray(parsed)) {
+        throw new Error('JSON datasets must contain an array of records.');
+      }
+      rows = parsed as DatasetRow[];
+    } else {
+      return NextResponse.json({ error: 'Unsupported file type. Use CSV or JSON.' }, { status: 400 });
+    }
+
+    const cleaned = cleanDataset(rows);
+    const numericFields = detectNumericFields(cleaned);
+    const dataset: DatasetRecord = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      uploadedAt: new Date().toISOString(),
+      fields: Object.keys(cleaned[0] ?? {}),
+      rowCount: cleaned.length,
+      sample: cleaned.slice(0, 20),
+      data: cleaned,
+      numericFields,
+      kpis: computeKpis(cleaned),
+      geoPoints: extractGeoPoints(cleaned)
+    };
+
+    saveDataset(dataset);
+
+    return NextResponse.json(dataset, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Failed to process dataset.' }, { status: 500 });
+  }
+}

--- a/src/app/api/upload/notebook/route.ts
+++ b/src/app/api/upload/notebook/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { parseNotebookFile } from '@/lib/notebook';
+import { saveNotebook } from '@/stores/data-store';
+import type { NotebookRecord } from '@/types/data';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'A notebook file is required.' }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const text = buffer.toString('utf-8');
+
+    const cells = parseNotebookFile(text);
+    const notebook: NotebookRecord = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      uploadedAt: new Date().toISOString(),
+      cells
+    };
+
+    saveNotebook(notebook);
+
+    return NextResponse.json(notebook, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Failed to process notebook.' }, { status: 500 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,89 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: #f5f5f7;
+  --foreground: #111827;
+  --muted: #e5e7eb;
+  --muted-foreground: #4b5563;
+  --border: #d1d5db;
+  --ring: #2563eb;
+  --primary: #2563eb;
+  --primary-foreground: #f9fafb;
+  --secondary: #1d4ed8;
+  --secondary-foreground: #f8fafc;
+  --accent: #0891b2;
+  --accent-foreground: #f8fafc;
+  --destructive: #dc2626;
+  --destructive-foreground: #fef2f2;
+  --font-sans: 'Inter';
+}
+
+[data-theme='dark'] {
+  --background: #0f172a;
+  --foreground: #f1f5f9;
+  --muted: #1e293b;
+  --muted-foreground: #cbd5f5;
+  --border: #1e293b;
+  --ring: #60a5fa;
+  --primary: #60a5fa;
+  --primary-foreground: #0f172a;
+  --secondary: #3b82f6;
+  --secondary-foreground: #0f172a;
+  --accent: #38bdf8;
+  --accent-foreground: #0f172a;
+  --destructive: #f87171;
+  --destructive-foreground: #0f172a;
+}
+
+html, body {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+body {
+  font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+* {
+  border-color: var(--border);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--muted);
+  border-radius: 9999px;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.markdown p {
+  margin-bottom: 0.75rem;
+}
+
+.markdown ul {
+  margin-left: 1.25rem;
+  list-style-type: disc;
+  margin-bottom: 0.75rem;
+}
+
+.markdown code {
+  background: var(--muted);
+  padding: 0.1rem 0.25rem;
+  border-radius: 0.375rem;
+  font-size: 0.85em;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import './globals.css';
+import { ThemeProvider } from '@/components/providers/theme-provider';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
+
+export const metadata: Metadata = {
+  title: 'Insights Studio Dashboard',
+  description:
+    'Upload data, explore insights, and review notebooks in a deploy-ready Next.js analytics workspace.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} bg-background text-foreground antialiased`}>
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/components/cards/kpi-card.tsx
+++ b/src/components/cards/kpi-card.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+interface KpiCardProps {
+  title: string;
+  value: string;
+  changeLabel?: string;
+  changeValue?: string;
+  icon?: ReactNode;
+}
+
+/**
+ * Compact key performance indicator card with optional change indicator.
+ */
+export function KpiCard({ title, value, changeLabel, changeValue, icon }: KpiCardProps) {
+  return (
+    <article className="flex flex-col gap-3 rounded-xl border border-border bg-background/60 p-4">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>{title}</span>
+        {icon}
+      </div>
+      <div className="text-2xl font-semibold">{value}</div>
+      {changeLabel && changeValue ? (
+        <p className="text-xs text-muted-foreground">
+          {changeLabel}: <span className="font-medium text-foreground">{changeValue}</span>
+        </p>
+      ) : null}
+    </article>
+  );
+}

--- a/src/components/cards/summary-card.tsx
+++ b/src/components/cards/summary-card.tsx
@@ -1,0 +1,17 @@
+interface SummaryCardProps {
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}
+
+export function SummaryCard({ title, description, action }: SummaryCardProps) {
+  return (
+    <section className="flex flex-col justify-between gap-3 rounded-xl border border-border bg-background/60 p-5">
+      <div>
+        <h3 className="text-base font-semibold">{title}</h3>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+      {action ? <div className="pt-2">{action}</div> : null}
+    </section>
+  );
+}

--- a/src/components/charts-client.tsx
+++ b/src/components/charts-client.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { useDatasets } from '@/hooks/use-datasets';
+import { LineChartCard } from '@/components/charts/line-chart';
+import { BarChartCard } from '@/components/charts/bar-chart';
+import { ScatterChartCard } from '@/components/charts/scatter-chart';
+import { HeatmapChart } from '@/components/charts/heatmap-chart';
+import { MapChart } from '@/components/charts/map-chart';
+import { buildLineChart, buildBarChart, buildScatterChart, buildHeatmap, extractGeoPoints } from '@/lib/chart-data';
+import { EmptyState } from '@/components/empty-state';
+
+export function ChartsClient() {
+  const { datasets, isLoading, error } = useDatasets();
+  const [activeId, setActiveId] = useState<string | undefined>(() => datasets[0]?.id);
+  const dataset = datasets.find((entry) => entry.id === activeId) ?? datasets[0];
+
+  if (isLoading) {
+    return <div className="h-64 animate-pulse rounded-xl border border-border bg-muted/40" />;
+  }
+
+  if (error) {
+    return <EmptyState title="Failed to load charts" description={error.message} />;
+  }
+
+  if (!dataset) {
+    return <EmptyState title="No datasets" description="Upload a dataset on the overview page to unlock visualisations." />;
+  }
+
+  const line = buildLineChart(dataset.data);
+  const bar = buildBarChart(dataset.data);
+  const scatter = buildScatterChart(dataset.data);
+  const heatmap = buildHeatmap(dataset.data);
+  const geo = extractGeoPoints(dataset.data);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-xl border border-border bg-background/60 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold">Dataset selection</h2>
+          <p className="text-sm text-muted-foreground">Choose an uploaded dataset to drive the charts below.</p>
+        </div>
+        <select
+          value={dataset.id}
+          onChange={(event) => setActiveId(event.target.value)}
+          className="w-full rounded-md border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+        >
+          {datasets.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        {line ? (
+          <LineChartCard
+            data={line.points}
+            xKey={line.xKey}
+            lineKeys={line.series}
+            title="Trend analysis"
+            description="Multi-series line chart built from numeric columns."
+          />
+        ) : (
+          <EmptyState title="Line chart unavailable" description="Need at least one numeric column to plot trends." />
+        )}
+        {bar ? (
+          <BarChartCard
+            data={bar.points}
+            xKey={bar.xKey}
+            barKeys={bar.series}
+            title="Category distribution"
+            description="Average value per category across the dataset."
+          />
+        ) : (
+          <EmptyState title="Bar chart unavailable" description="Requires a categorical and numeric column." />
+        )}
+        {scatter ? (
+          <ScatterChartCard
+            data={scatter.points}
+            xKey={scatter.xKey}
+            yKey={scatter.yKey}
+            sizeKey={scatter.sizeKey}
+            title="Scatter correlations"
+            description="Plot pairwise relationships across numeric columns."
+          />
+        ) : (
+          <EmptyState title="Scatter chart unavailable" description="Provide at least two numeric columns." />
+        )}
+        {heatmap ? (
+          <HeatmapChart
+            data={heatmap.points}
+            xCategories={heatmap.xCategories}
+            yCategories={heatmap.yCategories}
+            title="Heatmap density"
+            description="Cross-tabulate two categorical columns to reveal density patterns."
+          />
+        ) : (
+          <EmptyState title="Heatmap unavailable" description="Requires two categorical fields." />
+        )}
+        {geo.length ? (
+          <MapChart
+            points={geo}
+            title="Geospatial coverage"
+            description="Visualise latitude and longitude points if supplied."
+          />
+        ) : (
+          <EmptyState title="Map unavailable" description="Include latitude and longitude columns to enable mapping." />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/bar-chart.tsx
+++ b/src/components/charts/bar-chart.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from 'recharts';
+import type { ChartPoint } from '@/types/data';
+
+interface BarChartCardProps {
+  data: ChartPoint[];
+  xKey: string;
+  barKeys: string[];
+  title: string;
+  description?: string;
+}
+
+const palette = ['#2563eb', '#10b981', '#f97316', '#ec4899', '#6366f1'];
+
+export function BarChartCard({ data, xKey, barKeys, title, description }: BarChartCardProps) {
+  return (
+    <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 12, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="4 4" stroke="var(--border)" />
+            <XAxis dataKey={xKey} stroke="var(--muted-foreground)" tickLine={false} axisLine={false} />
+            <YAxis stroke="var(--muted-foreground)" tickLine={false} axisLine={false} allowDecimals />
+            <Tooltip contentStyle={{ background: 'var(--background)', border: '1px solid var(--border)', borderRadius: 12 }} />
+            <Legend />
+            {barKeys.map((key, index) => (
+              <Bar key={key} dataKey={key} fill={palette[index % palette.length]} radius={6} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/charts/heatmap-chart.tsx
+++ b/src/components/charts/heatmap-chart.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { HeatmapPoint } from '@/types/data';
+
+const ReactECharts = dynamic(() => import('echarts-for-react'), { ssr: false });
+
+interface HeatmapChartProps {
+  data: HeatmapPoint[];
+  xCategories: string[];
+  yCategories: string[];
+  title: string;
+  description?: string;
+}
+
+export function HeatmapChart({ data, xCategories, yCategories, title, description }: HeatmapChartProps) {
+  const option = {
+    tooltip: { position: 'top' },
+    grid: { top: 24, right: 12, bottom: 24, left: 80 },
+    xAxis: {
+      type: 'category',
+      data: xCategories,
+      splitArea: { show: true }
+    },
+    yAxis: {
+      type: 'category',
+      data: yCategories,
+      splitArea: { show: true }
+    },
+    visualMap: {
+      min: 0,
+      max: Math.max(...data.map((item) => item.value), 1),
+      calculable: true,
+      orient: 'horizontal',
+      left: 'center',
+      bottom: 0
+    },
+    series: [
+      {
+        name: 'Density',
+        type: 'heatmap',
+        data: data.map((item) => [item.xIndex, item.yIndex, item.value]),
+        label: { show: false },
+        emphasis: {
+          itemStyle: {
+            shadowBlur: 0,
+            borderColor: 'var(--ring)',
+            borderWidth: 2
+          }
+        }
+      }
+    ]
+  };
+
+  return (
+    <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <div className="h-96">
+        <ReactECharts style={{ height: '100%', width: '100%' }} option={option} notMerge lazyUpdate />
+      </div>
+    </section>
+  );
+}

--- a/src/components/charts/line-chart.tsx
+++ b/src/components/charts/line-chart.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import type { ChartPoint } from '@/types/data';
+
+interface LineChartCardProps {
+  data: ChartPoint[];
+  xKey: string;
+  lineKeys: string[];
+  title: string;
+  description?: string;
+}
+
+const palette = ['#2563eb', '#0891b2', '#16a34a', '#f97316', '#9333ea'];
+
+export function LineChartCard({ data, xKey, lineKeys, title, description }: LineChartCardProps) {
+  return (
+    <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 12, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="4 4" stroke="var(--border)" />
+            <XAxis dataKey={xKey} stroke="var(--muted-foreground)" tickLine={false} axisLine={false} />
+            <YAxis stroke="var(--muted-foreground)" tickLine={false} axisLine={false} allowDecimals />
+            <Tooltip contentStyle={{ background: 'var(--background)', border: '1px solid var(--border)', borderRadius: 12 }} />
+            <Legend />
+            {lineKeys.map((key, index) => (
+              <Line
+                key={key}
+                type="monotone"
+                dataKey={key}
+                strokeWidth={2}
+                dot={false}
+                stroke={palette[index % palette.length]}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/charts/map-chart.tsx
+++ b/src/components/charts/map-chart.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { ComposableMap, Geographies, Geography, Marker } from 'react-simple-maps';
+import type { GeoPoint } from '@/types/data';
+
+interface MapChartProps {
+  points: GeoPoint[];
+  title: string;
+  description?: string;
+}
+
+const geoUrl = 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json';
+
+export function MapChart({ points, title, description }: MapChartProps) {
+  return (
+    <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <div className="h-96">
+        <ComposableMap projectionConfig={{ scale: 145 }} className="h-full w-full">
+          <Geographies geography={geoUrl}>
+            {({ geographies }) =>
+              geographies.map((geo) => (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  className="fill-muted stroke-border stroke-[0.5px]"
+                />
+              ))
+            }
+          </Geographies>
+          {points.map((point) => (
+            <Marker key={point.id} coordinates={[point.longitude, point.latitude]}>
+              <circle r={4} className="fill-primary stroke-background stroke-[1.5px]" />
+              <text
+                textAnchor="middle"
+                y={-10}
+                className="text-xs font-medium fill-foreground"
+              >
+                {point.label ?? point.id}
+              </text>
+            </Marker>
+          ))}
+        </ComposableMap>
+      </div>
+    </section>
+  );
+}

--- a/src/components/charts/scatter-chart.tsx
+++ b/src/components/charts/scatter-chart.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { ResponsiveContainer, ScatterChart, CartesianGrid, XAxis, YAxis, Tooltip, Scatter, ZAxis } from 'recharts';
+import type { ScatterPoint } from '@/types/data';
+
+interface ScatterChartCardProps {
+  data: ScatterPoint[];
+  xKey: string;
+  yKey: string;
+  sizeKey?: string;
+  title: string;
+  description?: string;
+}
+
+export function ScatterChartCard({ data, xKey, yKey, sizeKey, title, description }: ScatterChartCardProps) {
+  return (
+    <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
+      </header>
+      <div className="h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 12, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="4 4" stroke="var(--border)" />
+            <XAxis dataKey={xKey} stroke="var(--muted-foreground)" tickLine={false} axisLine={false} type="number" />
+            <YAxis dataKey={yKey} stroke="var(--muted-foreground)" tickLine={false} axisLine={false} type="number" />
+            {sizeKey ? <ZAxis dataKey={sizeKey} range={[60, 400]} /> : null}
+            <Tooltip cursor={{ strokeDasharray: '2 2' }} contentStyle={{ background: 'var(--background)', border: '1px solid var(--border)', borderRadius: 12 }} />
+            <Scatter data={data} fill="var(--accent)" />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  flexRender,
+  useReactTable,
+  getFilteredRowModel
+} from '@tanstack/react-table';
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import type { DatasetRow } from '@/types/data';
+
+interface DataTableProps {
+  data: DatasetRow[];
+}
+
+export function DataTable({ data }: DataTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = useState('');
+
+  const columns = useMemo<ColumnDef<DatasetRow>[]>(() => {
+    if (!data[0]) return [];
+    return Object.keys(data[0]).map((key) => ({
+      header: key,
+      accessorKey: key
+    }));
+  }, [data]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel()
+  });
+
+  return (
+    <section className="space-y-4 rounded-xl border border-border bg-background/60 p-5">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-base font-semibold">Table explorer</h3>
+          <p className="text-sm text-muted-foreground">Sort, search, and filter your dataset without leaving the browser.</p>
+        </div>
+        <label className="flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring">
+          <MagnifyingGlassIcon className="h-4 w-4 text-muted-foreground" />
+          <input
+            value={globalFilter ?? ''}
+            onChange={(event) => setGlobalFilter(event.target.value)}
+            placeholder="Search rows"
+            className="w-full bg-transparent text-sm outline-none"
+          />
+        </label>
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-border text-sm">
+          <thead className="bg-muted/60 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    className="cursor-pointer px-3 py-2"
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {{
+                      asc: ' ↑',
+                      desc: ' ↓'
+                    }[header.column.getIsSorted() as string] ?? null}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="divide-y divide-border">
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id} className="hover:bg-muted/60">
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="whitespace-nowrap px-3 py-2">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  action?: ReactNode;
+}
+
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border bg-background/60 px-6 py-12 text-center">
+      <h3 className="text-base font-semibold">{title}</h3>
+      <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      {action ? <div className="pt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/src/components/explorer-client.tsx
+++ b/src/components/explorer-client.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { useDatasets } from '@/hooks/use-datasets';
+import { DataTable } from '@/components/data-table';
+import { EmptyState } from '@/components/empty-state';
+
+export function ExplorerClient() {
+  const { datasets, isLoading, error } = useDatasets();
+  const [activeId, setActiveId] = useState<string | undefined>(() => datasets[0]?.id);
+  const dataset = datasets.find((entry) => entry.id === activeId) ?? datasets[0];
+
+  if (isLoading) {
+    return <div className="h-64 animate-pulse rounded-xl border border-border bg-muted/40" />;
+  }
+
+  if (error) {
+    return <EmptyState title="Failed to load datasets" description={error.message} />;
+  }
+
+  if (!dataset) {
+    return <EmptyState title="No datasets yet" description="Upload data to explore rows and fields." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-xl border border-border bg-background/60 p-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold">Dataset explorer</h2>
+          <p className="text-sm text-muted-foreground">Interact with raw rows. Sorting and filtering happen client-side for quick iteration.</p>
+        </div>
+        <select
+          value={dataset.id}
+          onChange={(event) => setActiveId(event.target.value)}
+          className="w-full rounded-md border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+        >
+          {datasets.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Rows</p>
+          <p className="text-lg font-semibold">{dataset.rowCount.toLocaleString()}</p>
+        </div>
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Fields</p>
+          <p className="text-lg font-semibold">{dataset.fields.length}</p>
+        </div>
+        <div className="rounded-xl border border-border bg-background/60 p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Uploaded</p>
+          <p className="text-lg font-semibold">{new Date(dataset.uploadedAt).toLocaleString()}</p>
+        </div>
+      </div>
+
+      <DataTable data={dataset.data} />
+    </div>
+  );
+}

--- a/src/components/navigation/auth-status.tsx
+++ b/src/components/navigation/auth-status.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Placeholder component for authentication integration.
+ * Replace with your identity provider (NextAuth, Auth0, custom, etc.).
+ */
+export function AuthStatus() {
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<{ name: string } | null>(null);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setUser({ name: 'Analyst' });
+      setLoading(false);
+    }, 600);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Checking access&hellip;</p>;
+  }
+
+  if (!user) {
+    return (
+      <button
+        type="button"
+        className="inline-flex items-center justify-center rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted"
+      >
+        Connect authentication
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+      <span className="font-medium">{user.name}</span>
+      <span className="text-xs uppercase tracking-wide text-muted-foreground">Viewer</span>
+    </div>
+  );
+}

--- a/src/components/navigation/mobile-nav.tsx
+++ b/src/components/navigation/mobile-nav.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { usePathname } from 'next/navigation';
+import { ThemeToggle } from '@/components/theme-toggle';
+import { AuthStatus } from '@/components/navigation/auth-status';
+
+const links = [
+  { href: '/', label: 'Overview' },
+  { href: '/charts', label: 'Charts' },
+  { href: '/explorer', label: 'Explorer' },
+  { href: '/notebooks', label: 'Notebooks' }
+];
+
+export function MobileNav() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  return (
+    <div className="border-b border-border bg-background/80">
+      <div className="flex items-center justify-between px-4 py-3">
+        <Link href="/" className="text-base font-semibold">
+          Insights Studio
+        </Link>
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-expanded={open}
+          aria-controls="mobile-nav-menu"
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          {open ? <XMarkIcon className="h-5 w-5" /> : <Bars3Icon className="h-5 w-5" />}
+        </button>
+      </div>
+      {open ? (
+        <div id="mobile-nav-menu" className="space-y-2 border-t border-border px-4 py-3 text-sm">
+          {links.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`block rounded-md px-2 py-2 ${pathname === href ? 'bg-secondary text-secondary-foreground' : 'hover:bg-muted'}`}
+              onClick={() => setOpen(false)}
+            >
+              {label}
+            </Link>
+          ))}
+          <div className="border-t border-dashed border-border pt-3">
+            <AuthStatus />
+          </div>
+          <ThemeToggle className="w-full justify-center" />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ChartBarIcon, HomeIcon, TableCellsIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
+import { ThemeToggle } from '@/components/theme-toggle';
+import { AuthStatus } from '@/components/navigation/auth-status';
+import { clsx } from 'clsx';
+
+const links = [
+  { href: '/', label: 'Overview', icon: HomeIcon },
+  { href: '/charts', label: 'Charts', icon: ChartBarIcon },
+  { href: '/explorer', label: 'Explorer', icon: TableCellsIcon },
+  { href: '/notebooks', label: 'Notebooks', icon: DocumentTextIcon }
+];
+
+/**
+ * Fixed sidebar navigation that collapses on smaller screens.
+ */
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="flex h-full w-full flex-col gap-6 border-r border-border bg-background/80 p-4">
+      <div>
+        <Link href="/" className="block text-lg font-semibold tracking-tight">
+          Insights Studio
+        </Link>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Analytics workspace with secure upload pipeline.
+        </p>
+      </div>
+
+      <nav className="flex flex-1 flex-col gap-1">
+        {links.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={clsx(
+                'flex items-center gap-3 rounded-md border border-transparent px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring',
+                active
+                  ? 'bg-secondary text-secondary-foreground'
+                  : 'hover:bg-muted hover:text-foreground'
+              )}
+            >
+              <Icon className="h-5 w-5" aria-hidden />
+              <span>{label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="mt-auto flex flex-col gap-3 border-t border-dashed border-border pt-4">
+        <AuthStatus />
+        <ThemeToggle />
+      </div>
+    </aside>
+  );
+}

--- a/src/components/notebook-viewer.tsx
+++ b/src/components/notebook-viewer.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Fragment } from 'react';
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import theme from 'prism-react-renderer/themes/github';
+import type { NotebookCell } from '@/types/data';
+
+interface NotebookViewerProps {
+  title: string;
+  cells: NotebookCell[];
+}
+
+export function NotebookViewer({ title, cells }: NotebookViewerProps) {
+  return (
+    <article className="space-y-4 rounded-xl border border-border bg-background/60 p-5">
+      <header>
+        <h3 className="text-base font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">Review executed notebook cells with preserved output.</p>
+      </header>
+      <div className="space-y-6">
+        {cells.map((cell, index) => (
+          <section key={cell.id ?? index} className="space-y-3 rounded-lg border border-border bg-background p-4">
+            {cell.type === 'markdown' ? (
+              <div className="markdown text-sm leading-relaxed" dangerouslySetInnerHTML={{ __html: cell.html ?? '' }} />
+            ) : null}
+            {cell.type === 'code' ? (
+              <div className="space-y-3">
+                <Highlight {...defaultProps} theme={theme} code={cell.source.join('')} language={cell.language ?? 'python'}>
+                  {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                    <pre className={`${className} overflow-x-auto rounded-md border border-border bg-muted/40 p-3 text-xs`} style={style}>
+                      {tokens.map((line, i) => (
+                        <div key={i} {...getLineProps({ line, key: i })}>
+                          {line.map((token, key) => (
+                            <span key={key} {...getTokenProps({ token, key })} />
+                          ))}
+                        </div>
+                      ))}
+                    </pre>
+                  )}
+                </Highlight>
+                {cell.outputs?.length ? (
+                  <div className="space-y-2 rounded-md border border-dashed border-border bg-muted/40 p-3 text-xs">
+                    {cell.outputs.map((output, outputIndex) => (
+                      <Fragment key={outputIndex}>
+                        {output.type === 'stream' ? (
+                          <pre className="whitespace-pre-wrap text-foreground">{output.text}</pre>
+                        ) : null}
+                        {output.type === 'error' ? (
+                          <pre className="whitespace-pre-wrap text-destructive">{output.traceback?.join('\n')}</pre>
+                        ) : null}
+                        {output.type === 'display_data' || output.type === 'execute_result' ? (
+                          <div className="text-foreground" dangerouslySetInnerHTML={{ __html: output.html ?? '' }} />
+                        ) : null}
+                      </Fragment>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </section>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/src/components/notebooks-client.tsx
+++ b/src/components/notebooks-client.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { useNotebooks } from '@/hooks/use-notebooks';
+import { UploadNotebookForm } from '@/components/upload-notebook-form';
+import { NotebookViewer } from '@/components/notebook-viewer';
+import { EmptyState } from '@/components/empty-state';
+
+export function NotebooksClient() {
+  const { notebooks, isLoading, error, refresh } = useNotebooks();
+  const [activeId, setActiveId] = useState<string | undefined>(() => notebooks[0]?.id);
+  const notebook = notebooks.find((entry) => entry.id === activeId) ?? notebooks[0];
+
+  if (isLoading) {
+    return <div className="h-64 animate-pulse rounded-xl border border-border bg-muted/40" />;
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        title="Failed to load notebooks"
+        description={error.message}
+        action={
+          <button onClick={() => refresh()} className="rounded-md border border-border px-3 py-2 text-sm">
+            Retry
+          </button>
+        }
+      />
+    );
+  }
+
+  if (!notebook) {
+    return (
+      <div className="space-y-6">
+        <EmptyState
+          title="No notebooks yet"
+          description="Upload executed Jupyter notebooks to review code, markdown, and outputs."
+        />
+        <UploadNotebookForm onComplete={() => refresh()} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,280px)_1fr]">
+        <aside className="space-y-4 rounded-xl border border-border bg-background/60 p-5">
+          <div>
+            <h2 className="text-base font-semibold">Notebook library</h2>
+            <p className="text-sm text-muted-foreground">Select a notebook to render below. Upload new files at any time.</p>
+          </div>
+          <UploadNotebookForm onComplete={() => refresh()} />
+          <ul className="space-y-2">
+            {notebooks.map((entry) => (
+              <li key={entry.id}>
+                <button
+                  type="button"
+                  onClick={() => setActiveId(entry.id)}
+                  className={`w-full rounded-md border border-border px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-ring ${notebook.id === entry.id ? 'bg-secondary text-secondary-foreground' : 'hover:bg-muted'}`}
+                >
+                  <span className="block font-medium">{entry.name}</span>
+                  <span className="text-xs text-muted-foreground">Uploaded {new Date(entry.uploadedAt).toLocaleString()}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <NotebookViewer title={notebook.name} cells={notebook.cells} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/overview-client.tsx
+++ b/src/components/overview-client.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useDatasets } from '@/hooks/use-datasets';
+import { UploadDatasetForm } from '@/components/upload-dataset-form';
+import { KpiCard } from '@/components/cards/kpi-card';
+import { SummaryCard } from '@/components/cards/summary-card';
+import { EmptyState } from '@/components/empty-state';
+import { ArrowPathIcon, TableCellsIcon } from '@heroicons/react/24/outline';
+
+export function OverviewClient() {
+  const { datasets, isLoading, error, refresh } = useDatasets();
+  const primaryDataset = datasets[0];
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-32 animate-pulse rounded-xl border border-border bg-muted/40" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        title="Failed to load datasets"
+        description={error.message}
+        action={
+          <button onClick={() => refresh()} className="rounded-md border border-border px-3 py-2 text-sm">
+            Retry
+          </button>
+        }
+      />
+    );
+  }
+
+  if (!primaryDataset) {
+    return (
+      <div className="space-y-6">
+        <EmptyState
+          title="Upload your first dataset"
+          description="Import CSV or JSON data to unlock charting, table exploration, and derived KPIs."
+        />
+        <UploadDatasetForm onComplete={() => refresh()} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          title="Rows"
+          value={primaryDataset.kpis.totalRows.toLocaleString()}
+          changeLabel="Numeric columns"
+          changeValue={primaryDataset.kpis.numericColumns.toString()}
+          icon={<TableCellsIcon className="h-5 w-5 text-muted-foreground" />}
+        />
+        <KpiCard
+          title="Missing values"
+          value={primaryDataset.kpis.missingValues.toLocaleString()}
+          changeLabel="Last refresh"
+          changeValue={new Date(primaryDataset.kpis.lastUpdated).toLocaleString()}
+        />
+        <KpiCard
+          title="Fields"
+          value={primaryDataset.fields.length.toString()}
+          changeLabel="Geo features"
+          changeValue={primaryDataset.geoPoints.length.toString()}
+        />
+        <KpiCard
+          title="Datasets"
+          value={datasets.length.toString()}
+          changeLabel="Latest upload"
+          changeValue={new Date(primaryDataset.uploadedAt).toLocaleDateString()}
+          icon={<ArrowPathIcon className="h-5 w-5 text-muted-foreground" />}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <SummaryCard
+          title="Active dataset"
+          description={`Currently highlighting ${primaryDataset.name} with ${primaryDataset.rowCount.toLocaleString()} rows. Use the explorer to pivot through fields or refresh with a new upload.`}
+          action={
+            <button className="rounded-md border border-border px-3 py-2 text-sm" onClick={() => refresh()}>
+              Refresh data
+            </button>
+          }
+        />
+        <SummaryCard
+          title="Upload new dataset"
+          description="Kick off a new analysis run by importing structured CSV or JSON files. All parsing happens server-side before streaming to the client."
+          action={<UploadDatasetForm onComplete={() => refresh()} />}
+        />
+        <SummaryCard
+          title="Next steps"
+          description="Review charts, interrogate tables, and annotate notebooks. Authentication hooks are ready for integration with your identity provider."
+        />
+      </section>
+
+      <section className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold">Available datasets</h3>
+            <p className="text-sm text-muted-foreground">Switch between uploaded datasets on the charts and explorer pages.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refresh()}
+            className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <ArrowPathIcon className="h-4 w-4" />
+            Refresh
+          </button>
+        </header>
+        <ul className="space-y-3">
+          {datasets.map((dataset) => (
+            <li key={dataset.id} className="rounded-lg border border-border bg-background px-4 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium">{dataset.name}</p>
+                  <p className="text-xs text-muted-foreground">{dataset.rowCount.toLocaleString()} rows • {dataset.fields.length} fields</p>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Uploaded {new Date(dataset.uploadedAt).toLocaleString()}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ThemeProviderProps } from 'next-themes/dist/types';
+
+/**
+ * Wraps the application with the theme provider so that Tailwind's
+ * `dark:` variants respond to the current theme. The provider simply
+ * toggles a `data-theme` attribute on the `<html>` element.
+ */
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      {...props}
+      attribute="data-theme"
+      defaultTheme="light"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+import { SunIcon, MoonIcon } from '@heroicons/react/24/outline';
+import { ButtonHTMLAttributes } from 'react';
+
+/**
+ * Accessible button that toggles between light and dark themes.
+ * Styled without any drop shadows to honor the project guidelines.
+ */
+export function ThemeToggle({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  const isDark = mounted && theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      className={`inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 text-sm transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring ${className ?? ''}`}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      {...props}
+    >
+      {isDark ? (
+        <SunIcon className="h-4 w-4" />
+      ) : (
+        <MoonIcon className="h-4 w-4" />
+      )}
+      <span className="hidden sm:inline">{isDark ? 'Light' : 'Dark'} mode</span>
+    </button>
+  );
+}

--- a/src/components/upload-notebook-form.tsx
+++ b/src/components/upload-notebook-form.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+
+interface UploadNotebookFormProps {
+  onComplete?: () => void;
+}
+
+export function UploadNotebookForm({ onComplete }: UploadNotebookFormProps) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const fileInput = form.elements.namedItem('file') as HTMLInputElement | null;
+    const file = fileInput?.files?.[0];
+    if (!file) {
+      setStatus('error');
+      setMessage('Please choose an .ipynb file.');
+      return;
+    }
+
+    const body = new FormData();
+    body.append('file', file);
+
+    try {
+      setStatus('loading');
+      setMessage('Uploading…');
+      const res = await fetch('/api/upload/notebook', {
+        method: 'POST',
+        body
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || 'Upload failed');
+      }
+      setStatus('success');
+      setMessage('Notebook ingested.');
+      form.reset();
+      onComplete?.();
+    } catch (error) {
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'Upload failed');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3 rounded-xl border border-border bg-background/60 p-5">
+      <div>
+        <h3 className="text-base font-semibold">Upload notebook</h3>
+        <p className="text-sm text-muted-foreground">Drop in executed Jupyter notebooks to review code and outputs.</p>
+      </div>
+      <input
+        type="file"
+        name="file"
+        accept=".ipynb,application/x-ipynb+json"
+        className="w-full rounded-md border border-border px-3 py-2 text-sm file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium"
+      />
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-accent px-4 py-2 text-sm font-medium text-accent-foreground transition-colors hover:bg-accent/80 focus:outline-none focus:ring-2 focus:ring-ring"
+        disabled={status === 'loading'}
+      >
+        <ArrowUpTrayIcon className="h-4 w-4" />
+        {status === 'loading' ? 'Processing…' : 'Upload notebook'}
+      </button>
+      {message ? (
+        <p className={`text-xs ${status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}>{message}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/hooks/use-dataset.ts
+++ b/src/hooks/use-dataset.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import useSWR from 'swr';
+import type { DatasetRecord } from '@/types/data';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch dataset');
+  return (await res.json()) as DatasetRecord;
+};
+
+export function useDataset(id?: string) {
+  const { data, error, isLoading, mutate } = useSWR<DatasetRecord>(id ? `/api/datasets/${id}` : null, fetcher, {
+    revalidateOnFocus: false
+  });
+  return {
+    dataset: data,
+    error,
+    isLoading,
+    refresh: mutate
+  };
+}

--- a/src/hooks/use-datasets.ts
+++ b/src/hooks/use-datasets.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import useSWR from 'swr';
+import type { DatasetRecord } from '@/types/data';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch datasets');
+  return (await res.json()) as DatasetRecord[];
+};
+
+export function useDatasets() {
+  const { data, error, isLoading, mutate } = useSWR<DatasetRecord[]>('/api/datasets', fetcher, {
+    revalidateOnFocus: false
+  });
+  return {
+    datasets: data ?? [],
+    error,
+    isLoading,
+    refresh: mutate
+  };
+}

--- a/src/hooks/use-notebooks.ts
+++ b/src/hooks/use-notebooks.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import useSWR from 'swr';
+import type { NotebookRecord } from '@/types/data';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch notebooks');
+  return (await res.json()) as NotebookRecord[];
+};
+
+export function useNotebooks() {
+  const { data, error, isLoading, mutate } = useSWR<NotebookRecord[]>('/api/notebooks', fetcher, {
+    revalidateOnFocus: false
+  });
+  return {
+    notebooks: data ?? [],
+    error,
+    isLoading,
+    refresh: mutate
+  };
+}

--- a/src/lib/chart-data.ts
+++ b/src/lib/chart-data.ts
@@ -1,0 +1,139 @@
+import type { DatasetRow, HeatmapPoint, GeoPoint, ChartPoint, ScatterPoint } from '@/types/data';
+
+interface LineChartConfig {
+  xKey: string;
+  series: string[];
+  points: ChartPoint[];
+}
+
+interface BarChartConfig {
+  xKey: string;
+  series: string[];
+  points: ChartPoint[];
+}
+
+interface ScatterChartConfig {
+  xKey: string;
+  yKey: string;
+  sizeKey?: string;
+  points: ScatterPoint[];
+}
+
+interface HeatmapConfig {
+  xCategories: string[];
+  yCategories: string[];
+  points: HeatmapPoint[];
+}
+
+export function buildLineChart(rows: DatasetRow[]): LineChartConfig | null {
+  if (!rows.length) return null;
+  const keys = Object.keys(rows[0]);
+  const temporalKey = inferTemporalKey(rows) ?? keys[0];
+  const numericKeys = keys.filter((key) => rows.every((row) => typeof row[key] === 'number' || row[key] === null)).slice(0, 3);
+  if (!numericKeys.length) return null;
+  const points = rows.map((row, index) => ({
+    index,
+    [temporalKey]: row[temporalKey] ?? index,
+    ...numericKeys.reduce((acc, key) => ({ ...acc, [key]: row[key] ?? 0 }), {})
+  }));
+  return { xKey: temporalKey, series: numericKeys, points };
+}
+
+export function buildBarChart(rows: DatasetRow[]): BarChartConfig | null {
+  if (!rows.length) return null;
+  const keys = Object.keys(rows[0]);
+  const categoricalKey = keys.find((key) => rows.some((row) => typeof row[key] === 'string')) ?? keys[0];
+  const numericKey = keys.find((key) => typeof rows[0][key] === 'number');
+  if (!categoricalKey || !numericKey) return null;
+
+  const aggregated = new Map<string, { total: number; count: number }>();
+  rows.forEach((row) => {
+    const category = String(row[categoricalKey] ?? 'unknown');
+    const value = typeof row[numericKey] === 'number' ? (row[numericKey] as number) : 0;
+    const entry = aggregated.get(category) ?? { total: 0, count: 0 };
+    aggregated.set(category, { total: entry.total + value, count: entry.count + 1 });
+  });
+
+  const points = Array.from(aggregated.entries()).map(([category, { total, count }]) => ({
+    [categoricalKey]: category,
+    average: count ? total / count : 0
+  }));
+
+  return { xKey: categoricalKey, series: ['average'], points };
+}
+
+export function buildScatterChart(rows: DatasetRow[]): ScatterChartConfig | null {
+  if (!rows.length) return null;
+  const numericKeys = Object.keys(rows[0]).filter((key) => rows.every((row) => typeof row[key] === 'number'));
+  if (numericKeys.length < 2) return null;
+  const [xKey, yKey, sizeKey] = numericKeys;
+  const points = rows
+    .filter((row) => typeof row[xKey] === 'number' && typeof row[yKey] === 'number')
+    .map((row) => ({
+      [xKey]: row[xKey] as number,
+      [yKey]: row[yKey] as number,
+      ...(sizeKey ? { [sizeKey]: typeof row[sizeKey] === 'number' ? (row[sizeKey] as number) : undefined } : {})
+    }));
+  return { xKey, yKey, sizeKey, points };
+}
+
+export function buildHeatmap(rows: DatasetRow[]): HeatmapConfig | null {
+  if (!rows.length) return null;
+  const keys = Object.keys(rows[0]);
+  const categoricalKeys = keys.filter((key) => rows.some((row) => typeof row[key] === 'string'));
+  if (categoricalKeys.length < 2) return null;
+  const [xKey, yKey] = categoricalKeys;
+  const counts = new Map<string, number>();
+
+  rows.forEach((row) => {
+    const x = String(row[xKey] ?? 'unknown');
+    const y = String(row[yKey] ?? 'unknown');
+    const key = `${x}::${y}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  const xCategories = Array.from(new Set(rows.map((row) => String(row[xKey] ?? 'unknown'))));
+  const yCategories = Array.from(new Set(rows.map((row) => String(row[yKey] ?? 'unknown'))));
+
+  const points: HeatmapPoint[] = [];
+  xCategories.forEach((x, xi) => {
+    yCategories.forEach((y, yi) => {
+      const key = `${x}::${y}`;
+      points.push({ xIndex: xi, yIndex: yi, value: counts.get(key) ?? 0 });
+    });
+  });
+
+  return { xCategories, yCategories, points };
+}
+
+export function extractGeoPoints(rows: DatasetRow[]): GeoPoint[] {
+  if (!rows.length) return [];
+  const latKey = Object.keys(rows[0]).find((key) => key.includes('lat'));
+  const lonKey = Object.keys(rows[0]).find((key) => key.includes('lon')) ??
+    Object.keys(rows[0]).find((key) => key.includes('lng'));
+  if (!latKey || !lonKey) return [];
+  return rows
+    .filter((row) => typeof row[latKey] === 'number' && typeof row[lonKey] === 'number')
+    .map((row, index) => ({
+      id: `point-${index}`,
+      latitude: row[latKey] as number,
+      longitude: row[lonKey] as number,
+      label: typeof row['name'] === 'string' ? (row['name'] as string) : undefined
+    }));
+}
+
+function inferTemporalKey(rows: DatasetRow[]): string | null {
+  const keys = Object.keys(rows[0]);
+  for (const key of keys) {
+    if (key.includes('date') || key.includes('time')) {
+      return key;
+    }
+  }
+  for (const key of keys) {
+    const value = rows[0][key];
+    if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) {
+      return key;
+    }
+  }
+  return null;
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,31 @@
+import { parse } from 'csv-parse/sync';
+import type { DatasetRow } from '@/types/data';
+
+/**
+ * Parses CSV content into a collection of rows while trimming headers and
+ * coercing numeric values where possible.
+ */
+export function parseCsv(content: string): DatasetRow[] {
+  const records = parse(content, {
+    columns: true,
+    skipEmptyLines: true,
+    trim: true
+  }) as Record<string, string>[];
+
+  return records.map((record) => {
+    return Object.fromEntries(
+      Object.entries(record).map(([key, value]) => [key, coerceValue(value)])
+    );
+  });
+}
+
+function coerceValue(value: string | null): string | number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const numeric = Number(value);
+  if (!Number.isNaN(numeric) && value.trim() !== '') {
+    return numeric;
+  }
+  return value;
+}

--- a/src/lib/data-cleaning.ts
+++ b/src/lib/data-cleaning.ts
@@ -1,0 +1,33 @@
+import type { DatasetRow } from '@/types/data';
+
+/**
+ * Removes rows that are completely empty and normalises field names.
+ */
+export function cleanDataset(rows: DatasetRow[]): DatasetRow[] {
+  return rows
+    .map((row) => normalizeKeys(row))
+    .filter((row) => Object.values(row).some((value) => value !== null && value !== ''));
+}
+
+function normalizeKeys(row: DatasetRow): DatasetRow {
+  return Object.fromEntries(
+    Object.entries(row).map(([key, value]) => [key.trim().replace(/\s+/g, '_').toLowerCase(), value])
+  );
+}
+
+export function detectNumericFields(rows: DatasetRow[]): string[] {
+  if (!rows.length) return [];
+  const firstRow = rows[0];
+  return Object.keys(firstRow).filter((key) => rows.every((row) => typeof row[key] === 'number' || row[key] === null));
+}
+
+export function countMissingValues(rows: DatasetRow[]): number {
+  return rows.reduce((acc, row) => {
+    return (
+      acc +
+      Object.values(row).reduce((rowAcc, value) => {
+        return rowAcc + (value === null || value === '' ? 1 : 0);
+      }, 0)
+    );
+  }, 0);
+}

--- a/src/lib/kpis.ts
+++ b/src/lib/kpis.ts
@@ -1,0 +1,12 @@
+import type { DatasetKpis, DatasetRow } from '@/types/data';
+import { countMissingValues, detectNumericFields } from '@/lib/data-cleaning';
+
+export function computeKpis(rows: DatasetRow[]): DatasetKpis {
+  const numericFields = detectNumericFields(rows);
+  return {
+    totalRows: rows.length,
+    numericColumns: numericFields.length,
+    missingValues: countMissingValues(rows),
+    lastUpdated: new Date().toISOString()
+  };
+}

--- a/src/lib/notebook.ts
+++ b/src/lib/notebook.ts
@@ -1,0 +1,92 @@
+import { marked } from 'marked';
+import type { NotebookCell, NotebookOutput } from '@/types/data';
+
+interface RawNotebook {
+  cells: Array<{
+    cell_type: 'markdown' | 'code';
+    source: string[] | string;
+    id?: string;
+    metadata?: Record<string, unknown>;
+    outputs?: RawOutput[];
+  }>;
+  metadata?: {
+    language_info?: {
+      name?: string;
+    };
+  };
+}
+
+type RawOutput =
+  | {
+      output_type: 'stream';
+      text?: string[] | string;
+      name?: string;
+    }
+  | {
+      output_type: 'error';
+      traceback?: string[];
+    }
+  | {
+      output_type: 'display_data' | 'execute_result';
+      data?: Record<string, unknown>;
+    };
+
+export function parseNotebookFile(content: string): NotebookCell[] {
+  const notebook = JSON.parse(content) as RawNotebook;
+  const language = notebook.metadata?.language_info?.name;
+
+  return notebook.cells.map((cell) => {
+    const source = Array.isArray(cell.source) ? cell.source : [cell.source ?? ''];
+    if (cell.cell_type === 'markdown') {
+      return {
+        id: cell.id,
+        type: 'markdown' as const,
+        source,
+        html: marked.parse(source.join(''))
+      } satisfies NotebookCell;
+    }
+
+    return {
+      id: cell.id,
+      type: 'code' as const,
+      source,
+      language,
+      outputs: (cell.outputs ?? []).map(normalizeOutput)
+    } satisfies NotebookCell;
+  });
+}
+
+function normalizeOutput(output: RawOutput): NotebookOutput {
+  if (output.output_type === 'stream') {
+    const text = Array.isArray(output.text) ? output.text.join('') : output.text ?? '';
+    return { type: 'stream', text };
+  }
+
+  if (output.output_type === 'error') {
+    return { type: 'error', traceback: output.traceback ?? [] };
+  }
+
+  const data = output.data ?? {};
+  const html = extractHtml(data);
+  const text = typeof data['text/plain'] === 'string' ? (data['text/plain'] as string) : Array.isArray(data['text/plain']) ? (data['text/plain'] as string[]).join('') : undefined;
+
+  return {
+    type: output.output_type,
+    html,
+    text
+  };
+}
+
+function extractHtml(data: Record<string, unknown>): string | undefined {
+  if (typeof data['text/html'] === 'string') {
+    return data['text/html'] as string;
+  }
+  if (Array.isArray(data['text/html'])) {
+    return (data['text/html'] as string[]).join('');
+  }
+  if (typeof data['image/png'] === 'string') {
+    const base64 = data['image/png'] as string;
+    return `<img src="data:image/png;base64,${base64}" alt="Notebook output" class="max-h-96 rounded-md border border-border" />`;
+  }
+  return undefined;
+}

--- a/src/stores/data-store.ts
+++ b/src/stores/data-store.ts
@@ -1,0 +1,44 @@
+import type { DatasetRecord, NotebookRecord } from '@/types/data';
+
+interface DataStoreShape {
+  datasets: Map<string, DatasetRecord>;
+  notebooks: Map<string, NotebookRecord>;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __INSIGHTS_STORE__: DataStoreShape | undefined;
+}
+
+const store: DataStoreShape = globalThis.__INSIGHTS_STORE__ ?? {
+  datasets: new Map<string, DatasetRecord>(),
+  notebooks: new Map<string, NotebookRecord>()
+};
+
+if (!globalThis.__INSIGHTS_STORE__) {
+  globalThis.__INSIGHTS_STORE__ = store;
+}
+
+export function saveDataset(record: DatasetRecord) {
+  store.datasets.set(record.id, record);
+}
+
+export function listDatasets(): DatasetRecord[] {
+  return Array.from(store.datasets.values()).sort((a, b) => (a.uploadedAt < b.uploadedAt ? 1 : -1));
+}
+
+export function getDataset(id: string): DatasetRecord | undefined {
+  return store.datasets.get(id);
+}
+
+export function saveNotebook(record: NotebookRecord) {
+  store.notebooks.set(record.id, record);
+}
+
+export function listNotebooks(): NotebookRecord[] {
+  return Array.from(store.notebooks.values()).sort((a, b) => (a.uploadedAt < b.uploadedAt ? 1 : -1));
+}
+
+export function getNotebook(id: string): NotebookRecord | undefined {
+  return store.notebooks.get(id);
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,0 +1,79 @@
+export interface DatasetRecord {
+  id: string;
+  name: string;
+  uploadedAt: string;
+  fields: string[];
+  rowCount: number;
+  sample: DatasetRow[];
+  data: DatasetRow[];
+  numericFields: string[];
+  kpis: DatasetKpis;
+  geoPoints: GeoPoint[];
+}
+
+export type DatasetRow = Record<string, string | number | boolean | null>;
+
+export interface DatasetKpis {
+  totalRows: number;
+  numericColumns: number;
+  missingValues: number;
+  lastUpdated: string;
+}
+
+export interface ChartPoint {
+  [key: string]: string | number | null;
+}
+
+export interface ScatterPoint {
+  [key: string]: number;
+}
+
+export interface HeatmapPoint {
+  xIndex: number;
+  yIndex: number;
+  value: number;
+}
+
+export interface GeoPoint {
+  id: string;
+  latitude: number;
+  longitude: number;
+  label?: string;
+}
+
+export interface NotebookRecord {
+  id: string;
+  name: string;
+  uploadedAt: string;
+  cells: NotebookCell[];
+}
+
+export type NotebookCell =
+  | {
+      id?: string;
+      type: 'markdown';
+      source: string[];
+      html?: string;
+    }
+  | {
+      id?: string;
+      type: 'code';
+      source: string[];
+      language?: string;
+      outputs?: NotebookOutput[];
+    };
+
+export type NotebookOutput =
+  | {
+      type: 'stream';
+      text: string;
+    }
+  | {
+      type: 'error';
+      traceback?: string[];
+    }
+  | {
+      type: 'display_data' | 'execute_result';
+      html?: string;
+      text?: string;
+    };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,31 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        muted: 'var(--muted)',
+        'muted-foreground': 'var(--muted-foreground)',
+        border: 'var(--border)',
+        ring: 'var(--ring)',
+        primary: 'var(--primary)',
+        'primary-foreground': 'var(--primary-foreground)',
+        secondary: 'var(--secondary)',
+        'secondary-foreground': 'var(--secondary-foreground)',
+        accent: 'var(--accent)',
+        'accent-foreground': 'var(--accent-foreground)',
+        destructive: 'var(--destructive)',
+        'destructive-foreground': 'var(--destructive-foreground)'
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', 'system-ui', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/stores/*": ["src/stores/*"],
+      "@/types/*": ["src/types/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build a TypeScript Next.js application that parses uploaded CSV/JSON datasets and notebooks on the server and stores them in an in-memory registry
- implement responsive overview, charts, explorer, and notebook pages with Tailwind styling, reusable components, and theme/auth placeholders
- document local development, environment setup, deployment to Vercel, and guidance for extending datasets and notebook visualisations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f739ac1ba48328879f80ade0004136