### PR TITLE
Revamp overview UI with dataset insights and upload refreshes

### DIFF
--- a/src/app/(pages)/analysis/page.tsx
+++ b/src/app/(pages)/analysis/page.tsx
@@ -1,0 +1,29 @@
+import { ChartsClient } from '@/components/charts-client';
+import { SparklesIcon, PresentationChartLineIcon } from '@heroicons/react/24/outline';
+
+export default function AnalysisPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-4 rounded-3xl border border-border/60 bg-background/80 p-6 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground/80">Visual analytics</p>
+            <h1 className="mt-1 text-3xl font-semibold">Analysis</h1>
+          </div>
+          <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+            <SparklesIcon className="h-4 w-4" aria-hidden />
+            Auto-refreshed KPIs
+          </span>
+        </div>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Compare trends, correlations, and geographic patterns in a single dashboard. Charts respond instantly to dataset changes, ensuring reliable storytelling.
+        </p>
+        <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+          <PresentationChartLineIcon className="h-4 w-4" aria-hidden />
+          <span>Time series · Distribution · Scatter</span>
+        </div>
+      </header>
+      <ChartsClient />
+    </div>
+  );
+}

--- a/src/app/(pages)/datasets/page.tsx
+++ b/src/app/(pages)/datasets/page.tsx
@@ -1,0 +1,29 @@
+import { ExplorerClient } from '@/components/explorer-client';
+import { TableCellsIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+
+export default function DatasetsPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-4 rounded-3xl border border-border/60 bg-background/80 p-6 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground/80">Data grid</p>
+            <h1 className="mt-1 text-3xl font-semibold">Datasets</h1>
+          </div>
+          <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+            <ArrowUpTrayIcon className="h-4 w-4" aria-hidden />
+            Upload CSV or JSON
+          </span>
+        </div>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Explore every record with instant filtering, keyboard navigation, and responsive tables. All data remains scoped to your session for safe prototyping.
+        </p>
+        <div className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+          <TableCellsIcon className="h-4 w-4" aria-hidden />
+          <span>Sortable columns · In-memory queries</span>
+        </div>
+      </header>
+      <ExplorerClient />
+    </div>
+  );
+}

--- a/src/app/(pages)/settings/page.tsx
+++ b/src/app/(pages)/settings/page.tsx
@@ -1,0 +1,107 @@
+import { ThemeToggle } from '@/components/theme-toggle';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AdjustmentsHorizontalIcon,
+  BellAlertIcon,
+  ShieldCheckIcon,
+  ArrowPathIcon
+} from '@heroicons/react/24/outline';
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-4 rounded-3xl border border-border/60 bg-background/80 p-6 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground/80">Workspace controls</p>
+            <h1 className="mt-1 text-3xl font-semibold">Settings</h1>
+          </div>
+          <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+            <AdjustmentsHorizontalIcon className="h-4 w-4" aria-hidden />
+            Tailor your studio
+          </span>
+        </div>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Configure workspace behaviour, manage alerts, and control how uploaded data is retained. These settings apply to the current Insights Studio session.
+        </p>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="insights-fade-in">
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold">Workspace preferences</CardTitle>
+            <CardDescription>Toggle themes and interface density to suit your environment.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 p-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground">Theme</p>
+                <p className="text-sm text-muted-foreground">Switch between light and dark appearance instantly.</p>
+              </div>
+              <ThemeToggle />
+            </div>
+            <div className="flex items-center justify-between gap-4 rounded-2xl border border-border/60 bg-background/70 p-4">
+              <div>
+                <p className="text-sm font-semibold text-foreground">Compact mode</p>
+                <p className="text-sm text-muted-foreground">Control component spacing for smaller viewports.</p>
+              </div>
+              <span className="text-xs text-muted-foreground">Use the toggle on the Overview page</span>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="insights-fade-in">
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold">Notifications</CardTitle>
+            <CardDescription>Decide which events trigger toast alerts and email digests.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-background/70 p-4">
+              <BellAlertIcon className="mt-1 h-5 w-5 text-muted-foreground" aria-hidden />
+              <div className="space-y-2 text-sm text-muted-foreground">
+                <div>
+                  <p className="font-semibold text-foreground">Upload notifications</p>
+                  <p>Show a toast after datasets or notebooks finish processing.</p>
+                </div>
+                <div>
+                  <p className="font-semibold text-foreground">Refresh reminders</p>
+                  <p>Surface warnings when datasets go stale for more than 24 hours.</p>
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Manage notification channels
+            </button>
+          </CardContent>
+        </Card>
+
+        <Card className="insights-fade-in lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-xl font-semibold">Data retention</CardTitle>
+            <CardDescription>Control how long in-memory datasets stay available in the studio.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-start gap-3 rounded-2xl border border-border/60 bg-background/70 p-4">
+              <ShieldCheckIcon className="mt-1 h-5 w-5 text-muted-foreground" aria-hidden />
+              <div className="space-y-2 text-sm text-muted-foreground">
+                <p className="font-semibold text-foreground">Default retention</p>
+                <p>Uploads persist for the duration of this session and are discarded when the server restarts.</p>
+                <p>Trigger a manual reset below to clear cached datasets and notebooks immediately.</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-full border border-destructive/60 bg-destructive/10 px-4 py-2 text-sm font-semibold text-destructive transition-colors hover:bg-destructive/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+            >
+              <ArrowPathIcon className="h-4 w-4" aria-hidden />
+              Reset workspace cache
+            </button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,3 +130,18 @@ body::after {
   border-radius: 0.375rem;
   font-size: 0.85em;
 }
+
+@keyframes insights-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.insights-fade-in {
+  animation: insights-fade-in 0.6s ease-out both;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/providers/theme-provider';
+import { ToastProvider } from '@/components/ui/use-toast';
+import { Toaster } from '@/components/ui/toaster';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
@@ -16,7 +18,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} bg-background text-foreground antialiased`}>
         <ThemeProvider>
-          {children}
+          <ToastProvider>
+            {children}
+            <Toaster />
+          </ToastProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/cards/kpi-card.tsx
+++ b/src/components/cards/kpi-card.tsx
@@ -1,29 +1,41 @@
 import type { ReactNode } from 'react';
+import { clsx } from 'clsx';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+type Tone = 'neutral' | 'success' | 'warning' | 'danger';
 
 interface KpiCardProps {
   title: string;
   value: string;
-  changeLabel?: string;
-  changeValue?: string;
+  description?: string;
   icon?: ReactNode;
+  tone?: Tone;
+  className?: string;
 }
 
-/**
- * Compact key performance indicator card with optional change indicator.
- */
-export function KpiCard({ title, value, changeLabel, changeValue, icon }: KpiCardProps) {
+const toneMap: Record<Tone, string> = {
+  neutral: 'text-foreground',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger: 'text-destructive'
+};
+
+export function KpiCard({ title, value, description, icon, tone = 'neutral', className }: KpiCardProps) {
   return (
-    <article className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-background/70 p-5 backdrop-blur">
-      <div className="flex items-center justify-between text-sm text-muted-foreground">
-        <span>{title}</span>
-        {icon}
-      </div>
-      <div className="text-2xl font-semibold">{value}</div>
-      {changeLabel && changeValue ? (
-        <p className="text-xs text-muted-foreground">
-          {changeLabel}: <span className="font-medium text-foreground">{changeValue}</span>
-        </p>
-      ) : null}
-    </article>
+    <Card
+      className={clsx(
+        'insights-fade-in border-border/70 bg-background/90 transition-transform duration-200 hover:-translate-y-0.5 hover:border-accent/70 focus-within:-translate-y-0.5',
+        className
+      )}
+    >
+      <CardHeader className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-sm font-medium uppercase tracking-wide text-muted-foreground/80">{title}</CardTitle>
+          {icon ? <span className="rounded-full border border-border/60 bg-muted/40 p-2 text-muted-foreground">{icon}</span> : null}
+        </div>
+        <div className={clsx('text-3xl font-semibold leading-tight', toneMap[tone])}>{value}</div>
+        {description ? <CardDescription className="text-sm text-muted-foreground">{description}</CardDescription> : null}
+      </CardHeader>
+    </Card>
   );
 }

--- a/src/components/navigation/mobile-nav.tsx
+++ b/src/components/navigation/mobile-nav.tsx
@@ -9,9 +9,9 @@ import { AuthStatus } from '@/components/navigation/auth-status';
 
 const links = [
   { href: '/', label: 'Overview' },
-  { href: '/charts', label: 'Charts' },
-  { href: '/explorer', label: 'Explorer' },
-  { href: '/notebooks', label: 'Notebooks' }
+  { href: '/datasets', label: 'Datasets' },
+  { href: '/analysis', label: 'Analysis' },
+  { href: '/settings', label: 'Settings' }
 ];
 
 export function MobileNav() {

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -2,16 +2,16 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ChartBarIcon, HomeIcon, TableCellsIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
+import { ChartBarIcon, CircleStackIcon, Cog6ToothIcon, HomeIcon } from '@heroicons/react/24/outline';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { AuthStatus } from '@/components/navigation/auth-status';
 import { clsx } from 'clsx';
 
 const links = [
   { href: '/', label: 'Overview', icon: HomeIcon },
-  { href: '/charts', label: 'Charts', icon: ChartBarIcon },
-  { href: '/explorer', label: 'Explorer', icon: TableCellsIcon },
-  { href: '/notebooks', label: 'Notebooks', icon: DocumentTextIcon }
+  { href: '/datasets', label: 'Datasets', icon: CircleStackIcon },
+  { href: '/analysis', label: 'Analysis', icon: ChartBarIcon },
+  { href: '/settings', label: 'Settings', icon: Cog6ToothIcon }
 ];
 
 /**

--- a/src/components/overview-client.tsx
+++ b/src/components/overview-client.tsx
@@ -1,22 +1,138 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { useDatasets } from '@/hooks/use-datasets';
+import { useNotebooks } from '@/hooks/use-notebooks';
 import { UploadDatasetForm } from '@/components/upload-dataset-form';
 import { KpiCard } from '@/components/cards/kpi-card';
-import { SummaryCard } from '@/components/cards/summary-card';
 import { EmptyState } from '@/components/empty-state';
-import { ArrowPathIcon, TableCellsIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowPathIcon,
+  ChartBarIcon,
+  CircleStackIcon,
+  ClockIcon,
+  Cog6ToothIcon,
+  DocumentTextIcon,
+  ExclamationTriangleIcon,
+  MagnifyingGlassIcon,
+  SparklesIcon,
+  TableCellsIcon
+} from '@heroicons/react/24/outline';
+import { clsx } from 'clsx';
+import { useToast } from '@/components/ui/use-toast';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+
+const ACTIVE_DATASET_STORAGE_KEY = 'insights-active-dataset';
+const COMPACT_MODE_STORAGE_KEY = 'insights-compact-mode';
 
 export function OverviewClient() {
   const { datasets, isLoading, error, refresh } = useDatasets();
-  const primaryDataset = datasets[0];
+  const { notebooks, isLoading: notebooksLoading, error: notebooksError } = useNotebooks();
+  const { toast } = useToast();
+  const [activeDatasetId, setActiveDatasetId] = useState<string | null>(null);
+  const [compactMode, setCompactMode] = useState(false);
+  const [datasetQuery, setDatasetQuery] = useState('');
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedDataset = window.localStorage.getItem(ACTIVE_DATASET_STORAGE_KEY);
+    const storedCompact = window.localStorage.getItem(COMPACT_MODE_STORAGE_KEY);
+    if (storedDataset) {
+      setActiveDatasetId(storedDataset);
+    }
+    if (storedCompact) {
+      setCompactMode(storedCompact === 'true');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!datasets.length) {
+      return;
+    }
+    setActiveDatasetId((current) => {
+      if (current && datasets.some((dataset) => dataset.id === current)) {
+        return current;
+      }
+      return datasets[0]?.id ?? null;
+    });
+  }, [datasets]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (activeDatasetId) {
+      window.localStorage.setItem(ACTIVE_DATASET_STORAGE_KEY, activeDatasetId);
+    }
+  }, [activeDatasetId]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(COMPACT_MODE_STORAGE_KEY, compactMode ? 'true' : 'false');
+  }, [compactMode]);
+
+  const activeDataset = datasets.find((dataset) => dataset.id === activeDatasetId) ?? datasets[0];
+  const lastRefreshedText = activeDataset?.kpis.lastUpdated
+    ? new Date(activeDataset.kpis.lastUpdated).toLocaleString()
+    : 'Awaiting first upload';
+
+  const filteredDatasets = useMemo(() => {
+    const search = datasetQuery.trim().toLowerCase();
+    if (!search) {
+      return datasets;
+    }
+    return datasets.filter((dataset) => dataset.name.toLowerCase().includes(search));
+  }, [datasets, datasetQuery]);
+
+  async function handleRefreshClick(showToast = true) {
+    try {
+      setRefreshing(true);
+      await refresh();
+      if (showToast) {
+        toast({ title: 'Datasets refreshed', description: 'Latest metrics and uploads are synced.', variant: 'success' });
+      }
+    } catch (refreshError) {
+      toast({
+        title: 'Refresh failed',
+        description:
+          refreshError instanceof Error ? refreshError.message : 'Unable to refresh datasets at the moment.',
+        variant: 'warning'
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  function handleSetActiveDataset(id: string) {
+    setActiveDatasetId(id);
+    const dataset = datasets.find((entry) => entry.id === id);
+    if (dataset) {
+      toast({ title: 'Active dataset updated', description: `${dataset.name} is now highlighted for analysis.`, variant: 'success' });
+    }
+  }
+
+  function toggleCompactMode() {
+    setCompactMode((current) => !current);
+  }
 
   if (isLoading) {
     return (
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <div key={index} className="h-32 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
-        ))}
+      <div className="space-y-6">
+        <div className="h-40 animate-pulse rounded-3xl border border-border/60 bg-muted/40" />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="h-32 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
+              ))}
+            </div>
+            <div className="h-64 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
+            <div className="h-72 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
+          </div>
+          <div className="space-y-6">
+            <div className="h-64 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
+            <div className="h-48 animate-pulse rounded-2xl border border-border/60 bg-muted/40" />
+          </div>
+        </div>
       </div>
     );
   }
@@ -27,7 +143,12 @@ export function OverviewClient() {
         title="Failed to load datasets"
         description={error.message}
         action={
-          <button onClick={() => refresh()} className="rounded-full border border-border/60 px-3 py-2 text-sm hover:bg-muted/40">
+          <button
+            type="button"
+            onClick={() => void handleRefreshClick()}
+            className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <ArrowPathIcon className="h-4 w-4" />
             Retry
           </button>
         }
@@ -35,101 +156,371 @@ export function OverviewClient() {
     );
   }
 
-  if (!primaryDataset) {
-    return (
-      <div className="space-y-6">
-        <EmptyState
-          title="Upload your first dataset"
-          description="Import CSV or JSON data to unlock charting, table exploration, and derived KPIs."
-        />
-        <UploadDatasetForm onComplete={() => refresh()} />
-      </div>
-    );
-  }
+  const stackSpacing = compactMode ? 'space-y-4' : 'space-y-6';
+  const gridGap = compactMode ? 'gap-4' : 'gap-6';
+  const cardGap = compactMode ? 'gap-3' : 'gap-4';
+  const notebook = notebooks[0];
 
   return (
     <div className="space-y-6">
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <KpiCard
-          title="Rows"
-          value={primaryDataset.kpis.totalRows.toLocaleString()}
-          changeLabel="Numeric columns"
-          changeValue={primaryDataset.kpis.numericColumns.toString()}
-          icon={<TableCellsIcon className="h-5 w-5 text-muted-foreground" />}
-        />
-        <KpiCard
-          title="Missing values"
-          value={primaryDataset.kpis.missingValues.toLocaleString()}
-          changeLabel="Last refresh"
-          changeValue={new Date(primaryDataset.kpis.lastUpdated).toLocaleString()}
-        />
-        <KpiCard
-          title="Fields"
-          value={primaryDataset.fields.length.toString()}
-          changeLabel="Geo features"
-          changeValue={primaryDataset.geoPoints.length.toString()}
-        />
-        <KpiCard
-          title="Datasets"
-          value={datasets.length.toString()}
-          changeLabel="Latest upload"
-          changeValue={new Date(primaryDataset.uploadedAt).toLocaleDateString()}
-          icon={<ArrowPathIcon className="h-5 w-5 text-muted-foreground" />}
-        />
-      </section>
-
-      <section className="grid gap-4 lg:grid-cols-3">
-        <SummaryCard
-          title="Active dataset"
-          description={`Currently highlighting ${primaryDataset.name} with ${primaryDataset.rowCount.toLocaleString()} rows. Use the explorer to pivot through fields or refresh with a new upload.`}
-          action={
-            <button className="rounded-full border border-border/60 px-3 py-2 text-sm transition-colors hover:bg-muted/40" onClick={() => refresh()}>
-              Refresh data
-            </button>
-          }
-        />
-        <SummaryCard
-          title="Upload new dataset"
-          description="Kick off a new analysis run by importing structured CSV or JSON files. All parsing happens server-side before streaming to the client."
-          action={<UploadDatasetForm onComplete={() => refresh()} />}
-        />
-        <SummaryCard
-          title="Next steps"
-          description="Review charts, interrogate tables, and annotate notebooks. Authentication hooks are ready for integration with your identity provider."
-        />
-      </section>
-
-      <section className="space-y-3 rounded-2xl border border-border/60 bg-background/70 p-5 backdrop-blur">
-        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <header className="space-y-4 rounded-3xl border border-border/60 bg-background/80 p-6 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
-            <h3 className="text-base font-semibold">Available datasets</h3>
-            <p className="text-sm text-muted-foreground">Switch between uploaded datasets on the charts and explorer pages.</p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground/80">Workspace</p>
+            <h1 className="mt-1 text-3xl font-semibold">Insights Studio</h1>
           </div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+            <ClockIcon className="h-4 w-4" />
+            <span>Last refreshed: {lastRefreshedText}</span>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground">
+            <ol className="flex items-center gap-2">
+              <li className="font-medium text-foreground">Overview</li>
+              <li aria-hidden>›</li>
+              <li>{activeDataset ? activeDataset.name : 'No dataset selected'}</li>
+            </ol>
+          </nav>
           <button
             type="button"
-            onClick={() => refresh()}
-            className="inline-flex items-center gap-2 rounded-full border border-border/60 px-3 py-2 text-sm transition-colors hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-ring/60"
+            onClick={toggleCompactMode}
+            aria-pressed={compactMode}
+            className={clsx(
+              'inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-2 text-sm font-medium transition-colors',
+              'hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+            )}
           >
-            <ArrowPathIcon className="h-4 w-4" />
-            Refresh
+            <Cog6ToothIcon className="h-4 w-4" />
+            {compactMode ? 'Compact mode enabled' : 'Compact mode'}
           </button>
-        </header>
-        <ul className="space-y-3">
-          {datasets.map((dataset) => (
-            <li key={dataset.id} className="rounded-2xl border border-border/60 bg-background/80 px-4 py-3 backdrop-blur">
+        </div>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Upload datasets, monitor KPIs, and jump into deeper analysis. All uploads stay in-memory and are validated for fast, repeatable insights.
+        </p>
+      </header>
+
+      {!activeDataset ? (
+        <div className={clsx('grid', gridGap, 'xl:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)]')}>
+          <div className={clsx('space-y-6', stackSpacing)}>
+            <EmptyState
+              title="Upload your first dataset"
+              description="Import CSV or JSON data to unlock charting, table exploration, and derived KPIs."
+            />
+            <UploadDatasetForm onComplete={() => void handleRefreshClick(false)} />
+          </div>
+          <aside className={clsx('space-y-6', stackSpacing)}>
+            <Card className="insights-fade-in">
+              <CardHeader>
+                <CardTitle className="text-xl font-semibold">Workflow tips</CardTitle>
+                <CardDescription>
+                  Upload a dataset to enable the charts, explorer, and notebook playback panels.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>Use the drag-and-drop zone to add CSV or JSON files. Each upload remains private to this workspace.</p>
+                <p>Once processed, explore summaries on this page, pivot rows in Datasets, and replay notebooks under Analysis.</p>
+              </CardContent>
+            </Card>
+          </aside>
+        </div>
+      ) : (
+        <div className={clsx('grid', gridGap, 'xl:grid-cols-[minmax(0,1.75fr)_minmax(0,1fr)]')}>
+          <div className={clsx('space-y-6', stackSpacing)}>
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-semibold">Key metrics</h2>
+                <SparklesIcon className="h-5 w-5 text-muted-foreground" aria-hidden />
+              </div>
+              <div className={clsx('grid grid-cols-2 md:grid-cols-4', compactMode ? 'gap-3' : 'gap-4')}>
+                <KpiCard
+                  title="Rows"
+                  value={activeDataset.kpis.totalRows.toLocaleString()}
+                  description={`${activeDataset.fields.length} total fields`}
+                  icon={<CircleStackIcon className="h-4 w-4" aria-hidden />}
+                />
+                <KpiCard
+                  title="Numeric columns"
+                  value={activeDataset.kpis.numericColumns.toString()}
+                  description={`${activeDataset.numericFields.length} profiled metrics`}
+                  icon={<ChartBarIcon className="h-4 w-4" aria-hidden />}
+                />
+                <KpiCard
+                  title="Missing values"
+                  value={activeDataset.kpis.missingValues.toLocaleString()}
+                  description={
+                    activeDataset.kpis.missingValues === 0
+                      ? 'Healthy dataset'
+                      : 'Consider cleaning before analysis'
+                  }
+                  tone={activeDataset.kpis.missingValues === 0 ? 'success' : 'warning'}
+                  icon={<ExclamationTriangleIcon className="h-4 w-4" aria-hidden />}
+                />
+                <KpiCard
+                  title="Datasets"
+                  value={datasets.length.toString()}
+                  description={`Latest upload: ${new Date(activeDataset.uploadedAt).toLocaleDateString()}`}
+                  icon={<TableCellsIcon className="h-4 w-4" aria-hidden />}
+                />
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-xl font-semibold">Dataset overview</h2>
+                <button
+                  type="button"
+                  onClick={() => void handleRefreshClick()}
+                  className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-2 text-sm font-medium transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                  <ArrowPathIcon className={clsx('h-4 w-4', refreshing ? 'animate-spin' : undefined)} aria-hidden />
+                  Refresh
+                </button>
+              </div>
+              <Card className="insights-fade-in">
+                <CardHeader className="space-y-3">
+                  <CardTitle className="text-xl font-semibold">Active dataset</CardTitle>
+                  <CardDescription>
+                    Currently highlighting <span className="font-medium text-foreground">{activeDataset.name}</span> with{' '}
+                    {activeDataset.rowCount.toLocaleString()} rows. Use the Datasets tab to interrogate fields or pivot rows.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-3 md:grid-cols-3">
+                  <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-3">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Geo features</p>
+                    <p className="mt-2 text-sm text-foreground">{activeDataset.geoPoints.length}</p>
+                  </div>
+                  <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-3">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Sample size</p>
+                    <p className="mt-2 text-sm text-foreground">{activeDataset.sample.length} preview rows</p>
+                  </div>
+                  <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-3">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Last updated</p>
+                    <p className="mt-2 text-sm text-foreground">{lastRefreshedText}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section className={clsx('grid', 'lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]', compactMode ? 'gap-3' : 'gap-4')}>
+              <UploadDatasetForm
+                onComplete={() => void handleRefreshClick(false)}
+                lastUpload={{
+                  name: activeDataset.name,
+                  rowCount: activeDataset.rowCount,
+                  fieldCount: activeDataset.fields.length,
+                  refreshedAt: activeDataset.kpis.lastUpdated
+                }}
+              />
+              <div className="space-y-4">
+                <Card className="insights-fade-in">
+                  <CardHeader>
+                    <CardTitle className="text-xl font-semibold">Next steps</CardTitle>
+                    <CardDescription>Keep momentum with these recommended follow-ups.</CardDescription>
+                  </CardHeader>
+                  <CardContent className={clsx('grid md:grid-cols-3', cardGap)}>
+                    {[
+                      {
+                        title: 'Review charts',
+                        description: 'Explore visual dashboards and KPIs',
+                        icon: <ChartBarIcon className="h-5 w-5" aria-hidden />
+                      },
+                      {
+                        title: 'Interrogate tables',
+                        description: 'Drill into record-level data',
+                        icon: <TableCellsIcon className="h-5 w-5" aria-hidden />
+                      },
+                      {
+                        title: 'Annotate notebooks',
+                        description: 'Document and share insights',
+                        icon: <DocumentTextIcon className="h-5 w-5" aria-hidden />
+                      }
+                    ].map((item) => (
+                      <div
+                        key={item.title}
+                        className="rounded-2xl border border-border/60 bg-background/70 p-4 text-sm text-muted-foreground transition-colors hover:bg-muted/20"
+                      >
+                        <div className="mb-3 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-background/80 text-muted-foreground">
+                          {item.icon}
+                        </div>
+                        <p className="text-sm font-semibold text-foreground">{item.title}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{item.description}</p>
+                      </div>
+                    ))}
+                  </CardContent>
+                  <CardFooter className="pt-3">
+                    <a
+                      href="/analysis"
+                      className="inline-flex items-center gap-2 text-sm font-medium text-accent transition-colors hover:text-accent/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    >
+                      Continue analysis
+                      <SparklesIcon className="h-4 w-4" aria-hidden />
+                    </a>
+                  </CardFooter>
+                </Card>
+              </div>
+            </section>
+
+            <section className="space-y-4">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <p className="text-sm font-medium">{dataset.name}</p>
-                  <p className="text-xs text-muted-foreground">{dataset.rowCount.toLocaleString()} rows • {dataset.fields.length} fields</p>
+                  <h2 className="text-xl font-semibold">Available datasets</h2>
+                  <p className="text-base text-muted-foreground">Search, refresh, or mark a dataset as the active workspace.</p>
                 </div>
-                <div className="text-xs text-muted-foreground">
-                  Uploaded {new Date(dataset.uploadedAt).toLocaleString()}
+                <div className="flex flex-wrap items-center gap-2">
+                  <label className="flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-2 text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-accent">
+                    <MagnifyingGlassIcon className="h-4 w-4 text-muted-foreground" aria-hidden />
+                    <input
+                      value={datasetQuery}
+                      onChange={(event) => setDatasetQuery(event.target.value)}
+                      placeholder="Search datasets"
+                      className="w-40 bg-transparent text-sm outline-none"
+                      aria-label="Search datasets"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => void handleRefreshClick()}
+                    className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-2 text-sm font-medium transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    <ArrowPathIcon className={clsx('h-4 w-4', refreshing ? 'animate-spin' : undefined)} aria-hidden />
+                    Refresh
+                  </button>
                 </div>
               </div>
-            </li>
-          ))}
-        </ul>
-      </section>
+              <div className="overflow-hidden rounded-2xl border border-border/60">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">Dataset</th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">Rows</th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">Fields</th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">Uploaded</th>
+                      <th scope="col" className="px-4 py-3 text-left font-medium">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredDatasets.length ? (
+                      filteredDatasets.map((dataset) => {
+                        const isActive = activeDataset?.id === dataset.id;
+                        return (
+                          <tr
+                            key={dataset.id}
+                            className={clsx(
+                              'border-t border-border/60 text-sm transition-colors hover:bg-muted/30',
+                              isActive && 'bg-accent/10'
+                            )}
+                          >
+                            <td className="px-4 py-3 text-sm font-medium text-foreground">{dataset.name}</td>
+                            <td className="px-4 py-3 text-sm text-muted-foreground">{dataset.rowCount.toLocaleString()}</td>
+                            <td className="px-4 py-3 text-sm text-muted-foreground">{dataset.fields.length}</td>
+                            <td className="px-4 py-3 text-sm text-muted-foreground">
+                              {new Date(dataset.uploadedAt).toLocaleString()}
+                            </td>
+                            <td className="px-4 py-3 text-sm">
+                              {isActive ? (
+                                <span className="inline-flex items-center gap-2 rounded-full border border-accent/60 bg-accent/10 px-3 py-1 text-xs font-medium text-accent">
+                                  Active
+                                </span>
+                              ) : (
+                                <button
+                                  type="button"
+                                  onClick={() => handleSetActiveDataset(dataset.id)}
+                                  className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                                >
+                                  Set active
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })
+                    ) : (
+                      <tr>
+                        <td colSpan={5} className="px-4 py-6 text-center text-sm text-muted-foreground">
+                          No datasets match your search.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
+
+          <aside className={clsx('space-y-6', stackSpacing)}>
+            <Card className="insights-fade-in">
+              <CardHeader>
+                <CardTitle className="text-xl font-semibold">Field insights</CardTitle>
+                <CardDescription>Understand the feature mix within {activeDataset.name}.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-3">
+                  <p className="text-xs font-medium uppercase text-muted-foreground">Numeric coverage</p>
+                  <p className="mt-2 text-sm text-foreground">
+                    {activeDataset.numericFields.length} numeric fields (
+                    {Math.round((activeDataset.numericFields.length / Math.max(activeDataset.fields.length, 1)) * 100)}%)
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium uppercase text-muted-foreground">Key fields</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {activeDataset.fields.slice(0, 8).map((field) => (
+                      <span
+                        key={field}
+                        className="inline-flex items-center rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-foreground"
+                      >
+                        {field}
+                      </span>
+                    ))}
+                    {activeDataset.fields.length > 8 ? (
+                      <span className="text-xs text-muted-foreground">+ {activeDataset.fields.length - 8} more</span>
+                    ) : null}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="insights-fade-in">
+              <CardHeader>
+                <CardTitle className="text-xl font-semibold">Notebook playback</CardTitle>
+                <CardDescription>Quick glance at the most recent executed notebook.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                {notebooksLoading ? (
+                  <div className="h-32 animate-pulse rounded-xl border border-border/60 bg-muted/30" />
+                ) : notebooksError ? (
+                  <p className="text-destructive">{notebooksError.message}</p>
+                ) : notebook ? (
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">{notebook.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Uploaded {new Date(notebook.uploadedAt).toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-3">
+                      <p className="text-xs font-medium uppercase text-muted-foreground">Preview</p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {notebook.cells.slice(0, 2).map((cell) => cell.type).join(' · ')}
+                      </p>
+                    </div>
+                    <a
+                      href="/analysis"
+                      className="inline-flex items-center gap-2 text-sm font-medium text-accent transition-colors hover:text-accent/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    >
+                      Open in notebooks
+                      <DocumentTextIcon className="h-4 w-4" aria-hidden />
+                    </a>
+                  </div>
+                ) : (
+                  <p>No notebooks uploaded yet. Add one from the Analysis tab to replay code and outputs.</p>
+                )}
+              </CardContent>
+            </Card>
+          </aside>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import * as React from 'react';
+import { clsx } from 'clsx';
+
+type DivProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Card = React.forwardRef<HTMLDivElement, DivProps>(function Card(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'rounded-2xl border border-border/60 bg-background/80 text-foreground backdrop-blur transition-all duration-200',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+export const CardHeader = React.forwardRef<HTMLDivElement, DivProps>(function CardHeader(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('space-y-2 p-5', className)} {...props} />;
+});
+
+export const CardTitle = React.forwardRef<HTMLDivElement, DivProps>(function CardTitle(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('text-xl font-semibold', className)} {...props} />;
+});
+
+export const CardDescription = React.forwardRef<HTMLDivElement, DivProps>(function CardDescription(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('text-base text-muted-foreground', className)} {...props} />;
+});
+
+export const CardContent = React.forwardRef<HTMLDivElement, DivProps>(function CardContent(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('space-y-4 p-5 pt-0', className)} {...props} />;
+});
+
+export const CardFooter = React.forwardRef<HTMLDivElement, DivProps>(function CardFooter(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('p-5 pt-0', className)} {...props} />;
+});

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { clsx } from 'clsx';
+import { useToast, useToastState } from './use-toast';
+
+export function Toaster() {
+  const toasts = useToastState();
+  const { dismiss } = useToast();
+
+  if (!toasts.length) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-end px-4 sm:px-6">
+      <div className="flex w-full max-w-sm flex-col gap-3">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            role="status"
+            aria-live="assertive"
+            className={clsx(
+              'pointer-events-auto overflow-hidden rounded-2xl border border-border/60 bg-background/95 backdrop-blur',
+              'shadow-none ring-1 ring-border/80',
+              toast.variant === 'success' && 'border-emerald-400/70 ring-emerald-500/40',
+              toast.variant === 'warning' && 'border-amber-400/70 ring-amber-500/40',
+              toast.variant === 'destructive' && 'border-destructive/70 ring-destructive/40'
+            )}
+          >
+            <div className="flex items-start gap-3 px-4 py-3">
+              <div className="flex-1">
+                {toast.title ? (
+                  <p className="text-sm font-semibold text-foreground">{toast.title}</p>
+                ) : null}
+                {toast.description ? (
+                  <p className="mt-1 text-sm text-muted-foreground">{toast.description}</p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border/60 bg-background/70 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                onClick={() => dismiss(toast.id)}
+                aria-label="Dismiss notification"
+              >
+                <XMarkIcon className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/use-toast.tsx
+++ b/src/components/ui/use-toast.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import * as React from 'react';
+
+export type ToastVariant = 'default' | 'success' | 'warning' | 'destructive';
+
+export interface ToastOptions {
+  id?: string;
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+interface ToastContextValue {
+  toasts: Required<ToastOptions>[];
+  toast: (options: ToastOptions) => string;
+  dismiss: (id?: string) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null);
+
+function generateId() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<Required<ToastOptions>[]>([]);
+
+  const dismiss = React.useCallback((id?: string) => {
+    if (typeof id === 'string') {
+      setToasts((current) => current.filter((toast) => toast.id !== id));
+    } else {
+      setToasts([]);
+    }
+  }, []);
+
+  const toast = React.useCallback(
+    ({ duration = 4000, variant = 'default', ...options }: ToastOptions) => {
+      const id = options.id ?? generateId();
+      const record: Required<ToastOptions> = {
+        id,
+        title: options.title ?? '',
+        description: options.description ?? '',
+        duration,
+        variant
+      };
+      setToasts((current) => [...current.filter((toast) => toast.id !== id), record]);
+
+      if (duration > 0 && typeof window !== 'undefined') {
+        window.setTimeout(() => dismiss(id), duration);
+      }
+
+      return id;
+    },
+    [dismiss]
+  );
+
+  const value = React.useMemo<ToastContextValue>(
+    () => ({ toasts, toast, dismiss }),
+    [dismiss, toast, toasts]
+  );
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToast() {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  const { toast, dismiss } = context;
+  return { toast, dismiss };
+}
+
+export function useToastState() {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToastState must be used within a ToastProvider');
+  }
+  return context.toasts;
+}

--- a/src/components/upload-dataset-form.tsx
+++ b/src/components/upload-dataset-form.tsx
@@ -1,33 +1,75 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
-import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import { type DragEvent, useEffect, useRef, useState } from 'react';
+import {
+  ArrowUpTrayIcon,
+  DocumentArrowUpIcon,
+  InformationCircleIcon
+} from '@heroicons/react/24/outline';
+import { useToast } from '@/components/ui/use-toast';
 
 interface UploadDatasetFormProps {
   onComplete?: () => void;
+  lastUpload?: {
+    name: string;
+    rowCount: number;
+    fieldCount: number;
+    refreshedAt: string;
+  };
 }
 
-export function UploadDatasetForm({ onComplete }: UploadDatasetFormProps) {
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+export function UploadDatasetForm({ onComplete, lastUpload }: UploadDatasetFormProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const progressTimerRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<'idle' | 'dragging' | 'uploading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string>('');
+  const [progress, setProgress] = useState<number>(0);
+  const [fileName, setFileName] = useState<string>('');
+  const { toast } = useToast();
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const fileInput = form.elements.namedItem('file') as HTMLInputElement | null;
-    const file = fileInput?.files?.[0];
-    if (!file) {
-      setStatus('error');
-      setMessage('Please choose a CSV or JSON file.');
-      return;
+  useEffect(() => {
+    return () => {
+      if (progressTimerRef.current) {
+        window.clearInterval(progressTimerRef.current);
+      }
+    };
+  }, []);
+
+  function updateProgress(value: number) {
+    setProgress(value);
+  }
+
+  function startProgressLoop() {
+    updateProgress(12);
+    if (progressTimerRef.current) {
+      window.clearInterval(progressTimerRef.current);
     }
+    progressTimerRef.current = window.setInterval(() => {
+      setProgress((current) => {
+        if (current >= 90) {
+          return current;
+        }
+        return current + 6;
+      });
+    }, 180);
+  }
 
+  function stopProgressLoop() {
+    if (progressTimerRef.current) {
+      window.clearInterval(progressTimerRef.current);
+      progressTimerRef.current = null;
+    }
+  }
+
+  async function handleUpload(file: File) {
     const body = new FormData();
     body.append('file', file);
 
     try {
-      setStatus('loading');
-      setMessage('Uploading…');
+      setStatus('uploading');
+      setFileName(file.name);
+      setMessage('Uploading dataset…');
+      startProgressLoop();
       const res = await fetch('/api/upload/dataset', {
         method: 'POST',
         body
@@ -38,37 +80,145 @@ export function UploadDatasetForm({ onComplete }: UploadDatasetFormProps) {
       }
       setStatus('success');
       setMessage('Dataset processed successfully.');
-      form.reset();
+      updateProgress(100);
+      toast({
+        title: 'Dataset uploaded',
+        description: `${file.name} is ready to explore.`,
+        variant: 'success'
+      });
+      window.setTimeout(() => {
+        updateProgress(0);
+      }, 600);
       onComplete?.();
     } catch (error) {
       setStatus('error');
-      setMessage(error instanceof Error ? error.message : 'Upload failed');
+      const description = error instanceof Error ? error.message : 'Upload failed';
+      setMessage(description);
+      toast({ title: 'Upload failed', description, variant: 'destructive' });
+      updateProgress(0);
+    } finally {
+      stopProgressLoop();
     }
   }
 
+  async function handleFileSelection(files: FileList | null) {
+    const file = files?.[0];
+    if (!file) {
+      setStatus('error');
+      setMessage('Please choose a CSV or JSON file.');
+      return;
+    }
+    await handleUpload(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  function handleBrowseClick() {
+    fileInputRef.current?.click();
+  }
+
+  function handleDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setStatus('idle');
+    handleFileSelection(event.dataTransfer.files);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    if (status !== 'uploading') {
+      setStatus('dragging');
+    }
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    if (status === 'dragging') {
+      setStatus('idle');
+    }
+  }
+
+  const lastUploadText = lastUpload
+    ? `Last upload: ${lastUpload.name}, ${lastUpload.rowCount.toLocaleString()} rows • ${lastUpload.fieldCount} fields — refreshed ${new Date(
+        lastUpload.refreshedAt
+      ).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+    : 'No uploads yet. New data stays in-memory for rapid iteration.';
+
+  const isUploading = status === 'uploading';
+  const helperText = status === 'dragging' ? 'Release to upload.' : message;
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-3 rounded-2xl border border-border/60 bg-background/70 p-6 backdrop-blur">
-      <div>
-        <h3 className="text-base font-semibold">Upload dataset</h3>
-        <p className="text-sm text-muted-foreground">Accepted formats: CSV and JSON. Data is stored in-memory only.</p>
+    <section className="space-y-4 rounded-3xl border border-border/60 bg-background/80 p-5 backdrop-blur">
+      <header className="space-y-2">
+        <p className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Upload dataset</p>
+        <p className="text-base text-muted-foreground">
+          Drop CSV or JSON files to refresh the active workspace. Data stays within this session for analysis.
+        </p>
+      </header>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={handleBrowseClick}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleBrowseClick();
+          }
+        }}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        aria-label="Upload a dataset"
+        className={`border-2 border-dashed ${
+          status === 'dragging' ? 'border-accent bg-accent/10' : 'border-border/70'
+        } rounded-2xl p-6 text-center transition-colors hover:bg-muted/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`}
+      >
+        <DocumentArrowUpIcon className="mx-auto mb-3 h-8 w-8 text-muted-foreground" aria-hidden />
+        <p className="text-sm text-foreground">Drop CSV or JSON here, or</p>
+        <div className="mt-3 flex justify-center">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <ArrowUpTrayIcon className="h-4 w-4" aria-hidden />
+            Browse files
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">Accepted formats: CSV, JSON. Stored in memory only.</p>
       </div>
       <input
+        ref={fileInputRef}
         type="file"
         name="file"
         accept=".csv,.json,application/json,text/csv"
-        className="w-full rounded-md border border-border/60 bg-background/60 px-3 py-2 text-sm backdrop-blur file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-2 file:text-sm file:font-medium"
+        className="hidden"
+        onChange={(event) => handleFileSelection(event.target.files)}
       />
-      <button
-        type="submit"
-        className="inline-flex items-center justify-center gap-2 rounded-full border border-border/60 bg-secondary/90 px-4 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring/60"
-        disabled={status === 'loading'}
-      >
-        <ArrowUpTrayIcon className="h-4 w-4" />
-        {status === 'loading' ? 'Processing…' : 'Upload dataset'}
-      </button>
-      {message ? (
-        <p className={`text-xs ${status === 'error' ? 'text-destructive' : 'text-muted-foreground'}`}>{message}</p>
+      {isUploading ? (
+        <div className="space-y-2">
+          <div className="h-2 w-full rounded-full bg-muted/50">
+            <div
+              className="h-full rounded-full bg-accent transition-all duration-150"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">Processing {fileName}</p>
+        </div>
       ) : null}
-    </form>
+      {helperText ? (
+        <p
+          className={`text-sm ${
+            status === 'error' ? 'text-destructive' : status === 'dragging' ? 'text-accent' : 'text-muted-foreground'
+          }`}
+          aria-live="polite"
+        >
+          {helperText}
+        </p>
+      ) : null}
+      <div className="flex items-start gap-2 rounded-xl border border-dashed border-border/70 bg-muted/20 p-3 text-left">
+        <InformationCircleIcon className="mt-0.5 h-5 w-5 text-muted-foreground" aria-hidden />
+        <p className="text-xs text-muted-foreground">{lastUploadText}</p>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild the overview workspace with a structured header, KPI grid, dataset overview, search/filter table, and detail pane that persist the active dataset preference
- replace the upload form with a drag-and-drop card that tracks progress, surfaces last-upload details, and raises toast notifications on completion
- add reusable card and toast primitives, update navigation to the new Datasets/Analysis/Settings structure, and scaffold those pages for the refreshed IA

## Testing
- npm run lint *(fails: Next.js lint command prompted for configuration and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68f77dd525b083289415f43ef33e2b14