### PR TITLE
Fix Tailwind PostCSS plugin usage and compact button styles

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,6 @@
 // postcss.config.mjs
 export default {
   plugins: {
-    '@tailwindcss/postcss': {}, // Tailwind v4 PostCSS bridge
+    "@tailwindcss/postcss": {},
   },
 };

--- a/src/app/explore/FiltersPanel.tsx
+++ b/src/app/explore/FiltersPanel.tsx
@@ -99,7 +99,7 @@ export function FiltersPanel({ features, selectedFeatures, diagnosis, standardiz
           className="w-full"
         />
       </div>
-      <div className="flex items-center justify-between gap-3 rounded-md border border-[rgb(var(--border))] px-3 py-2">
+      <div className="flex items-center justify-between gap-2 rounded-md border border-[rgb(var(--border))] px-3 py-2">
         <div>
           <div className="text-sm font-medium text-[rgb(var(--fg))]">Standardize</div>
           <div className="text-xs text-[rgb(var(--muted))]">Z-score normalize selected features</div>
@@ -113,7 +113,7 @@ export function FiltersPanel({ features, selectedFeatures, diagnosis, standardiz
         <ColumnMultiSelect options={features} selected={storeFeatures.length ? storeFeatures : selectedFeatures} onChange={handleFeaturesChange} />
         <p className="mt-2 text-xs text-[rgb(var(--muted))]">Select up to 12 features for dense visualizations.</p>
       </div>
-      <Button variant="outline" className="justify-center" onClick={handleReset}>
+      <Button variant="outline" size="xs" className="justify-center" onClick={handleReset}>
         Reset filters
       </Button>
     </div>
@@ -127,7 +127,8 @@ export function FiltersPanel({ features, selectedFeatures, diagnosis, standardiz
         </div>
         <Button
           variant="outline"
-          className="h-9 px-3 text-xs md:hidden"
+          size="xs"
+          className="md:hidden"
           onClick={() => setOpen((prev) => !prev)}
           aria-expanded={open}
           aria-controls="filters-panel"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,31 +1,5 @@
 @import "tailwindcss";
 
-:root {
-  --bg: 255 255 255;
-  --fg: 17 24 39;
-  --muted: 107 114 128;
-  --border: 229 231 235;
-  --accent: 37 99 235;
-  --benign: 16 185 129;
-  --malignant: 239 68 68;
-  color-scheme: light;
-}
-
-.dark {
-  --bg: 9 9 11;
-  --fg: 229 231 235;
-  --muted: 163 163 163;
-  --border: 39 39 42;
-  --accent: 96 165 250;
-  --benign: 52 211 153;
-  --malignant: 248 113 113;
-  color-scheme: dark;
-}
-
-* {
-  box-shadow: none !important;
-}
-
 body {
   @apply bg-[rgb(var(--bg))] text-[rgb(var(--fg))] font-sans antialiased;
 }
@@ -70,4 +44,37 @@ a {
     text-decoration: none;
     color: inherit;
   }
+}
+
+:root {
+  --bg: 255 255 255;
+  --fg: 17 24 39;
+  --muted: 107 114 128;
+  --border: 229 231 235;
+  --accent: 37 99 235;
+  --benign: 16 185 129;
+  --malignant: 239 68 68;
+  color-scheme: light;
+}
+
+.dark {
+  --bg: 9 9 11;
+  --fg: 229 231 235;
+  --muted: 163 163 163;
+  --border: 39 39 42;
+  --accent: 96 165 250;
+  --benign: 52 211 153;
+  --malignant: 248 113 113;
+  color-scheme: dark;
+}
+
+/* No shadows anywhere */
+* {
+  box-shadow: none !important;
+}
+
+@layer utilities {
+  .btn-compact { height: 2rem; padding-inline: 0.625rem; font-size: 0.875rem; } /* h-8 px-2.5 text-sm */
+  .btn-compact-xs { height: 1.75rem; padding-inline: 0.5rem; font-size: 0.75rem; } /* h-7 */
+  .btn-icon { height: 2rem; width: 2rem; padding: 0; }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,8 @@ body {
 }
 
 a {
-  @apply text-accent underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] focus:ring-offset-2 focus:ring-offset-[rgb(var(--bg))];
+  color: rgb(var(--accent));
+  @apply underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] focus:ring-offset-2 focus:ring-offset-[rgb(var(--bg))];
 }
 
 :focus-visible {

--- a/src/app/report/ModelMetricsPanel.tsx
+++ b/src/app/report/ModelMetricsPanel.tsx
@@ -43,12 +43,12 @@ export function ModelMetricsPanel({ initial }: ModelMetricsPanelProps) {
 
   return (
     <div className="rounded-lg border border-[rgb(var(--border))] p-3 md:p-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
           <h3 className="text-lg font-semibold text-[rgb(var(--fg))]">Model metrics</h3>
           <p className="text-sm text-[rgb(var(--muted))]">Paste new metrics JSON to update this section.</p>
         </div>
-        <Button variant="outline" onClick={handleApply}>
+        <Button variant="outline" size="xs" onClick={handleApply}>
           Apply JSON
         </Button>
       </div>

--- a/src/app/report/PrintButton.tsx
+++ b/src/app/report/PrintButton.tsx
@@ -5,7 +5,7 @@ import { PrinterIcon } from "@/components/icons";
 
 export function PrintButton() {
   return (
-    <Button variant="outline" onClick={() => window.print()} className="gap-2">
+    <Button variant="outline" size="xs" onClick={() => window.print()} className="gap-1.5">
       <PrinterIcon className="h-4 w-4" />
       Print report
     </Button>

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -58,8 +58,11 @@ export function DataTable({ rows, columns, visibleColumns, title, controls, empt
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
-                <tr key={row.id} className="border-b border-[rgb(var(--border))] odd:bg-[rgb(var(--bg))] even:bg-[rgb(var(--bg))]/60">
+              {rows.map((row, index) => (
+                <tr
+                  key={`${row.id}-${index}`}
+                  className="border-b border-[rgb(var(--border))] odd:bg-[rgb(var(--bg))] even:bg-[rgb(var(--bg))]/60"
+                >
                   <td className="px-3 py-2 font-mono text-xs">{row.id}</td>
                   <td className="px-3 py-2 text-sm font-medium text-[rgb(var(--fg))]">
                     {row.diagnosis === "M" ? "Malignant" : "Benign"}

--- a/src/components/data/DataTable.tsx
+++ b/src/components/data/DataTable.tsx
@@ -26,7 +26,7 @@ export function DataTable({ rows, columns, visibleColumns, title, controls, empt
 
   return (
     <section className="rounded-lg border border-[rgb(var(--border))]">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[rgb(var(--border))] px-3 py-3 md:px-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[rgb(var(--border))] px-3 py-3 md:px-4">
         <div>
           {title ? <h3 className="text-sm font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">{title}</h3> : null}
           <p className="text-xs text-[rgb(var(--muted))]">{rows.length} rows</p>

--- a/src/components/data/DownloadButton.tsx
+++ b/src/components/data/DownloadButton.tsx
@@ -43,7 +43,7 @@ export function DownloadButton({ rows, columns, filename = "subset.csv" }: Downl
   };
 
   return (
-    <Button variant="outline" onClick={handleDownload} className="gap-2">
+    <Button variant="outline" size="xs" onClick={handleDownload} className="gap-1.5">
       <DownloadIcon className="h-4 w-4" />
       Export CSV
     </Button>

--- a/src/components/data/MetricCard.tsx
+++ b/src/components/data/MetricCard.tsx
@@ -12,7 +12,7 @@ export function MetricCard({ label, value, description, className }: MetricCardP
     <div
       tabIndex={0}
       className={cn(
-        "flex flex-col gap-2 rounded-lg border border-[rgb(var(--border))] p-3 md:p-4 transition focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] hover:ring-1 hover:ring-[rgb(var(--border))]",
+        "flex flex-col gap-2 rounded-lg border border-[rgb(var(--border))] p-3 md:p-3 transition focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] hover:ring-1 hover:ring-[rgb(var(--border))]",
         className
       )}
     >

--- a/src/components/forms/ColumnMultiSelect.tsx
+++ b/src/components/forms/ColumnMultiSelect.tsx
@@ -47,6 +47,7 @@ export function ColumnMultiSelect({ options, selected, onChange }: ColumnMultiSe
       <Button
         type="button"
         variant="outline"
+        size="xs"
         className="min-w-[180px] justify-between"
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
@@ -69,7 +70,7 @@ export function ColumnMultiSelect({ options, selected, onChange }: ColumnMultiSe
           </div>
           <div className="flex max-h-60 flex-col gap-2 overflow-auto pr-1">
             {options.map((option) => (
-              <label key={option} className="flex items-center gap-3 text-sm">
+              <label key={option} className="flex items-center gap-2 text-sm">
                 <Checkbox
                   checked={selected.includes(option)}
                   onCheckedChange={(next) => toggle(option, next)}

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -25,7 +25,7 @@ export function SideNav({ onNavigate }: { onNavigate?: () => void }) {
             href={item.href}
             onClick={onNavigate}
             className={cn(
-              "flex items-center gap-3 rounded-md border border-[rgb(var(--border))] px-3 py-2 text-sm font-medium transition hover:ring-1 hover:ring-[rgb(var(--border))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))]",
+              "flex items-center gap-2 rounded-md border border-[rgb(var(--border))] px-3 py-2 text-sm font-medium transition hover:ring-1 hover:ring-[rgb(var(--border))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))]",
               active ? "bg-[rgb(var(--accent))]/10" : ""
             )}
           >

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -43,8 +43,8 @@ export function ThemeToggle() {
   const toggleTheme = () => setTheme((prev) => (prev === "light" ? "dark" : "light"));
 
   return (
-    <Button aria-label="Toggle theme" variant="outline" size="icon" className="rounded-full" onClick={toggleTheme}>
-      {theme === "light" ? <MoonIcon className="h-5 w-5" /> : <SunIcon className="h-5 w-5" />}
+    <Button aria-label="Toggle theme" variant="outline" icon size="xs" className="rounded-full" onClick={toggleTheme}>
+      {theme === "light" ? <MoonIcon className="h-4 w-4" /> : <SunIcon className="h-4 w-4" />}
     </Button>
   );
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -34,15 +34,15 @@ export function TopBar({ onMenu }: { onMenu: () => void }) {
   return (
     <header className="flex items-center gap-4 border-b border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-3">
       <div className="flex items-center gap-2 lg:hidden">
-        <Button variant="outline" size="icon" onClick={onMenu} aria-label="Open navigation">
-          <MenuIcon className="h-5 w-5" />
+        <Button variant="outline" icon size="xs" onClick={onMenu} aria-label="Open navigation">
+          <MenuIcon className="h-4 w-4" />
         </Button>
       </div>
       <div className="hidden flex-col lg:flex">
         <span className="text-xs uppercase text-[rgb(var(--muted))]">Breast Cancer EDA</span>
         <span className="text-lg font-semibold">Tumor Diagnostics Analytics</span>
       </div>
-      <div className="flex flex-1 items-center gap-3">
+      <div className="flex flex-1 items-center gap-2">
         <Input
           value={search}
           onChange={(event) => setSearch(event.target.value)}
@@ -50,7 +50,7 @@ export function TopBar({ onMenu }: { onMenu: () => void }) {
           className="max-w-lg"
           aria-label="Search"
         />
-        <div className="ml-auto flex items-center gap-3">
+        <div className="ml-auto flex items-center gap-2">
           <div className="hidden items-center gap-2 rounded-md border border-[rgb(var(--border))] px-3 py-2 text-xs font-medium text-[rgb(var(--muted))] sm:flex">
             <FilterIcon className="h-4 w-4" />
             <span>{diagnosisFilter}</span>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,44 +1,52 @@
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
-type Variant = "default" | "accent" | "outline";
-type Size = "sm" | "md" | "lg" | "icon";
-
-const variantClasses: Record<Variant, string> = {
-  default:
-    "border border-[rgb(var(--border))] bg-transparent text-[rgb(var(--fg))] hover:ring-1 hover:ring-[rgb(var(--border))]",
-  accent: "border border-[rgb(var(--accent))] bg-[rgb(var(--accent))] text-white hover:ring-1 hover:ring-[rgb(var(--accent))]",
-  outline: "border border-[rgb(var(--border))] bg-transparent text-[rgb(var(--fg))] hover:ring-1 hover:ring-[rgb(var(--border))]"
-};
-
-const sizeClasses: Record<Size, string> = {
-  sm: "px-2.5 py-1.5 text-xs",
-  md: "px-3 py-1.5 text-sm",
-  lg: "px-4 py-2 text-base",
-  icon: "h-9 w-9 p-0"
-};
-
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: Variant;
-  size?: Size;
-}
-
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "md", ...props }, ref) => {
-    return (
-      <button
-        ref={ref}
-        className={cn(
-          "inline-flex items-center justify-center gap-2 rounded-md font-medium transition focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] disabled:pointer-events-none disabled:opacity-50",
-          variantClasses[variant],
-          sizeClasses[size],
-          className
-        )}
-        {...props}
-      />
-    );
+const buttonVariants = cva(
+  "inline-flex items-center justify-center select-none whitespace-nowrap " +
+    "rounded-md border border-[rgb(var(--border))] " +
+    "bg-[rgb(var(--bg))] text-[rgb(var(--fg))] " +
+    "hover:ring-1 hover:ring-[rgb(var(--border))] " +
+    "focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))] shadow-none",
+  {
+    variants: {
+      variant: {
+        default: "",
+        outline: "bg-transparent",
+        ghost: "bg-transparent border-transparent",
+        link: "border-transparent underline-offset-4 hover:underline"
+      },
+      size: {
+        xs: "h-7 px-2.5 text-xs gap-1",
+        sm: "h-8 px-3 text-sm gap-1.5",
+        md: "h-9 px-3.5 text-sm gap-2",
+        lg: "h-10 px-4 text-base gap-2"
+      },
+      icon: {
+        true: "px-0 aspect-square",
+        false: ""
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "sm",
+      icon: false
+    }
   }
 );
-Button.displayName = "Button";
 
-export { Button };
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+  icon?: boolean;
+}
+
+export function Button({ className, icon, size, variant, ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(buttonVariants({ size, variant, icon }), className)}
+      {...props}
+    />
+  );
+}

--- a/src/lib/class-variance-authority.ts
+++ b/src/lib/class-variance-authority.ts
@@ -1,0 +1,50 @@
+export type VariantMap = Record<string, Record<string, string>>;
+
+type VariantInput<V extends VariantMap> = {
+  [K in keyof V]?: keyof V[K] | boolean | null | undefined;
+};
+
+type DefaultVariants<V extends VariantMap> = {
+  [K in keyof V]?: keyof V[K];
+};
+
+type CvaOptions<V extends VariantMap> = {
+  variants?: V;
+  defaultVariants?: DefaultVariants<V>;
+};
+
+type InferProps<T> = T extends (props?: infer P) => any ? NonNullable<P> : never;
+
+export type VariantProps<T> = InferProps<T>;
+
+function normalizeVariant(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+export function cva<V extends VariantMap>(base: string, options: CvaOptions<V> = {}) {
+  const variants = options.variants ?? ({} as V);
+  const defaultVariants = options.defaultVariants ?? ({} as DefaultVariants<V>);
+
+  return (props?: VariantInput<V>) => {
+    const classes: string[] = [base].filter(Boolean);
+    const merged: Record<string, unknown> = { ...defaultVariants, ...(props ?? {}) };
+
+    (Object.keys(variants) as Array<keyof V>).forEach((key) => {
+      const map = variants[key];
+      if (!map) return;
+      const raw = merged[key as string];
+      const normalized = normalizeVariant(raw);
+      if (!normalized) return;
+      const selected = map[normalized as keyof V[typeof key]];
+      if (selected) {
+        classes.push(selected);
+      }
+    });
+
+    return classes.filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
+  };
+}
+
+export default cva;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     "paths": {
       "@/*": [
         "./src/*"
+      ],
+      "class-variance-authority": [
+        "./src/lib/class-variance-authority"
       ]
     },
     "plugins": [


### PR DESCRIPTION
## Summary
- update the Tailwind PostCSS bridge and global stylesheet for the v4 import and compact utility helpers
- replace the button component with the new compact variant system and add a local class-variance-authority shim
- tighten padding, gaps, and button sizing across the navigation, filters, and data toolbars to match the compact spec

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68f798aae7548328a7e8af31792ea6c7